### PR TITLE
Fix documentation mistakes in unsafe_unlink.c

### DIFF
--- a/unsafe_unlink.c
+++ b/unsafe_unlink.c
@@ -26,8 +26,8 @@ int main()
 	printf("We create a fake chunk inside chunk0.\n");
 	printf("We setup the 'next_free_chunk' (fd) of our fake chunk to point near to &chunk0_ptr so that P->fd->bk = P.\n");
 	chunk0_ptr[2] = (uint64_t) &chunk0_ptr-(sizeof(uint64_t)*3);
-	printf("We setup the 'next_free_chunk' (bk) of our fake chunk to point near to &chunk0_ptr so that P->bk->fd = P.\n");
-	printf("With this setup we can pass this check: (P->fd->bk != P || P->bk->fd != P) != False\n");
+	printf("We setup the 'previous_free_chunk' (bk) of our fake chunk to point near to &chunk0_ptr so that P->bk->fd = P.\n");
+	printf("With this setup we can pass this check: (P->fd->bk != P || P->bk->fd != P) == False\n");
 	chunk0_ptr[3] = (uint64_t) &chunk0_ptr-(sizeof(uint64_t)*2);
 	printf("Fake chunk fd: %p\n",(void*) chunk0_ptr[2]);
 	printf("Fake chunk bk: %p\n",(void*) chunk0_ptr[3]);


### PR DESCRIPTION
We want to reach the else branch in https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=ef04360b918bceca424482c6db03cc5ec90c3e00;hb=07c18a008c2ed8f5660adba2b778671db159a141#l1347

So (FD->bk != P || BK->fd != P) needs to evaluate to False, right? Correct me if I'm wrong!

