### PR TITLE
Use `make install` in the build script

### DIFF
--- a/glibc_build.sh
+++ b/glibc_build.sh
@@ -76,7 +76,9 @@ if [ -z $GLIBC_VERSION ]; then
 fi
 
 # Prepare output dir
-OUTPUT_DIR="$VERSION/$GLIBC_VERSION/${DIR_HOST}_${DIR_TCACHE}"
+OUTPUT_DIR=`pwd`/glibc_versions/"$GLIBC_VERSION/${DIR_HOST}_${DIR_TCACHE}"
+mkdir -p $OUTPUT_DIR/etc
+touch $OUTPUT_DIR/etc/ld.so.conf
 
 # Get glibc source
 if [ ! -d "$SRC" ]; then
@@ -105,19 +107,8 @@ else
     echo "  -> Clearing build directory"
     rm -rf ./*
 fi
-eval ../"$SRC"/configure --prefix=/usr $BUILD_OPTS
+eval ../"$SRC"/configure --prefix=$OUTPUT_DIR $BUILD_OPTS
 echo "$OUTPUT_DIR" > ./how2heap_build_cmd
 make -j "$make_threads"
-cd -
-
-# Save compiled
-if [ "$(ls -A $OUTPUT_DIR 2>/dev/null)" ]; then
-    echo "  -> Directory \"$OUTPUT_DIR\" exists and is not empty, skipping copy step"
-    exit
-fi
-mkdir -p "$OUTPUT_DIR"
-
-echo "  -> Copying libraries to $OUTPUT_DIR"
-cd "$BUILD"
-find . \( -name '*.so' -or -name '*.a' \) -exec rsync -aR "{}" "../$OUTPUT_DIR" \;
+make install
 cd -

--- a/glibc_build.sh
+++ b/glibc_build.sh
@@ -77,8 +77,6 @@ fi
 
 # Prepare output dir
 OUTPUT_DIR=`pwd`/glibc_versions/"$GLIBC_VERSION/${DIR_HOST}_${DIR_TCACHE}"
-mkdir -p $OUTPUT_DIR/etc
-touch $OUTPUT_DIR/etc/ld.so.conf
 
 # Get glibc source
 if [ ! -d "$SRC" ]; then

--- a/glibc_run.sh
+++ b/glibc_run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 VERSION="./glibc_versions"
+DIR_TCACHE='tcache'
+DIR_HOST='x64'
+OUTPUT_DIR="$VERSION/$1/${DIR_HOST}_${DIR_TCACHE}/lib"
 
 if [[ $# < 2 ]]; then
     echo "Usage: $0 <version> <target>";
@@ -8,17 +11,17 @@ if [[ $# < 2 ]]; then
 fi
 
 # Get glibc source
-if [ ! -e "$VERSION/libc-$1.so" ]; then
+if [ ! -e "$OUTPUT_DIR/libc-$1.so" ]; then
     echo "Error: Glibc-version wasn't build. Build it first:"
     echo "./build_glibc $1 <#make-threads"
 fi
 
 curr_interp=$(readelf -l "$2" | grep 'Requesting' | cut -d':' -f2 | tr -d ' ]')
-target_interp="$VERSION/ld-$1.so"
+target_interp="$OUTPUT_DIR/ld-$1.so"
 
 if [[ $curr_interp != $target_interp ]];
 then
     patchelf --set-interpreter "$target_interp" "$2"
 fi
 
-LD_PRELOAD="$VERSION/libc-$1.so" "$2"
+LD_PRELOAD="$OUTPUT_DIR/libc-$1.so" "$2"


### PR DESCRIPTION
The build script wasn't working for me, because it wasn't generating the `libc-2.XX.so`. I think the correct solution is to use the `--prefix` argument and then run `make install`.