### PR TITLE
add disable tcache and i686 option to glibc_run.sh

### DIFF
--- a/glibc_run.sh
+++ b/glibc_run.sh
@@ -3,25 +3,55 @@
 VERSION="./glibc_versions"
 DIR_TCACHE='tcache'
 DIR_HOST='x64'
-OUTPUT_DIR="$VERSION/$1/${DIR_HOST}_${DIR_TCACHE}/lib"
+GLIBC_VERSION=''
+TARGET=''
+
+# Handle arguments
+function show_help {
+    echo "Usage: $0 <version> <target> [-h] [-disable-tcache] [-i686]"
+}
 
 if [[ $# < 2 ]]; then
-    echo "Usage: $0 <version> <target>";
+    show_help
     exit 1
 fi
 
+GLIBC_VERSION=$1
+TARGET=$2
+
+while :; do
+    case $3 in
+        -h|-\?|--help)
+            show_help
+            exit
+            ;;
+        -disable-tcache)
+            DIR_TCACHE='notcache'
+            ;;
+        -i686)
+            DIR_HOST='i686'
+            ;;
+        '')
+            break
+            ;;
+    esac
+    shift
+done
+
+OUTPUT_DIR="$VERSION/$GLIBC_VERSION/${DIR_HOST}_${DIR_TCACHE}/lib"
+
 # Get glibc source
-if [ ! -e "$OUTPUT_DIR/libc-$1.so" ]; then
+if [ ! -e "$OUTPUT_DIR/libc-$GLIBC_VERSION.so" ]; then
     echo "Error: Glibc-version wasn't build. Build it first:"
-    echo "./build_glibc $1 <#make-threads"
+    echo "./build_glibc $GLIBC_VERSION <#make-threads"
 fi
 
-curr_interp=$(readelf -l "$2" | grep 'Requesting' | cut -d':' -f2 | tr -d ' ]')
-target_interp="$OUTPUT_DIR/ld-$1.so"
+curr_interp=$(readelf -l "$TARGET" | grep 'Requesting' | cut -d':' -f2 | tr -d ' ]')
+target_interp="$OUTPUT_DIR/ld-$GLIBC_VERSION.so"
 
 if [[ $curr_interp != $target_interp ]];
 then
-    patchelf --set-interpreter "$target_interp" "$2"
+    patchelf --set-interpreter "$target_interp" "$TARGET"
 fi
 
-"$2"
+"$TARGET"


### PR DESCRIPTION
`glibc_build.sh` has features to build without tcache and x86 versions of libc. Adding similar features for `glibc_run.sh`.

Earlier
```
$ CFLAGS="-m32" make /tmp/test
cc -m32 -std=c99 -g    /tmp/test.c   -o /tmp/test
$ ./glibc_build.sh 2.26 -j 8 -disable-tcache -i686
...
$ ./glibc_run.sh 2.26 /tmp/test
Error: Glibc-version wasn't build. Build it first:
./build_glibc 2.26 <#make-threads
warning: working around a Linux kernel bug by creating a hole of 4096 bytes in ‘/tmp/test’
./glibc_run.sh: line 27: /tmp/test: No such file or directory
$ ldd /tmp/test
	linux-gate.so.1 (0xf7f9d000)
	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d7a000)
	./glibc_versions/2.26/x64_tcache/lib/ld-2.26.so => /lib/ld-linux.so.2 (0xf7f9e000)
$ ll ./glibc_versions/2.26/x64_tcache/lib/ld-2.26.so
ls: cannot access './glibc_versions/2.26/x64_tcache/lib/ld-2.26.so': No such file or directory
```

After this fix
```
$ CFLAGS="-m32" make /tmp/test
cc -m32 -std=c99 -g    /tmp/test.c   -o /tmp/test
$ ./glibc_run.sh 2.26 /tmp/test -i686 -disable-tcache
... works ...
$ ldd /tmp/test
	linux-gate.so.1 (0xf7fd1000)
	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7dab000)
	./glibc_versions/2.26/i686_notcache/lib/ld-2.26.so => /lib/ld-linux.so.2 (0xf7fd2000)
$ ll ./glibc_versions/2.26/i686_notcache/lib/ld-2.26.so
-rwxr-xr-x 1 sudhakar sudhakar 170K Jun  5 20:42 ./glibc_versions/2.26/i686_notcache/lib/ld-2.26.so
$ rm /tmp/test
$ CFLAGS="" make /tmp/test
cc  -std=c99 -g    /tmp/test.c   -o /tmp/test
./glibc_run.sh 2.26 /tmp/test
... works ...
```
