### PR TITLE
Add heaptrace to tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ The `malloc_playground.c` file given is the source for a program that prompts th
 
 Examine the glibc heap in gdb: https://github.com/scwuaptx/Pwngdb
 
+## heaptrace
+
+Helps you visualize heap operations by replacing addresses with symbols: https://github.com/Arinerron/heaptrace
+
 # Other resources
 
 Some good heap exploitation resources, roughly in order of their publication, are:


### PR DESCRIPTION
This PR adds a link to a pretty mature, stable heap debugger project I've been working on called heaptrace: https://github.com/Arinerron/heaptrace

Its purpose is to help users visualize heap operations when doing heap pwn by replacing addresses with symbols.