### PR TITLE
stack_buffer_2 size must change from glibc 2.27 onwards

### DIFF
--- a/glibc_2.27/house_of_lore.c
+++ b/glibc_2.27/house_of_lore.c
@@ -33,7 +33,7 @@ int main(int argc, char * argv[]){
 
 
   intptr_t* stack_buffer_1[4] = {0};
-  intptr_t* stack_buffer_2[3] = {0};
+  intptr_t* stack_buffer_2[4] = {0};
   void* fake_freelist[7][4];
 
   fprintf(stderr, "\nWelcome to the House of Lore\n");

--- a/glibc_2.31/house_of_lore.c
+++ b/glibc_2.31/house_of_lore.c
@@ -33,7 +33,7 @@ int main(int argc, char * argv[]){
 
 
   intptr_t* stack_buffer_1[4] = {0};
-  intptr_t* stack_buffer_2[3] = {0};
+  intptr_t* stack_buffer_2[4] = {0};
   void* fake_freelist[7][4];
 
   fprintf(stderr, "\nWelcome to the House of Lore\n");

--- a/glibc_2.32/house_of_lore.c
+++ b/glibc_2.32/house_of_lore.c
@@ -33,7 +33,7 @@ int main(int argc, char * argv[]){
 
 
   intptr_t* stack_buffer_1[4] = {0};
-  intptr_t* stack_buffer_2[3] = {0};
+  intptr_t* stack_buffer_2[4] = {0};
   void* fake_freelist[7][4];
 
   fprintf(stderr, "\nWelcome to the House of Lore\n");

--- a/glibc_2.33/house_of_lore.c
+++ b/glibc_2.33/house_of_lore.c
@@ -33,7 +33,7 @@ int main(int argc, char * argv[]){
 
 
   intptr_t* stack_buffer_1[4] = {0};
-  intptr_t* stack_buffer_2[3] = {0};
+  intptr_t* stack_buffer_2[4] = {0};
   void* fake_freelist[7][4];
 
   fprintf(stderr, "\nWelcome to the House of Lore\n");

--- a/glibc_2.34/house_of_lore.c
+++ b/glibc_2.34/house_of_lore.c
@@ -33,7 +33,7 @@ int main(int argc, char * argv[]){
 
 
   intptr_t* stack_buffer_1[4] = {0};
-  intptr_t* stack_buffer_2[3] = {0};
+  intptr_t* stack_buffer_2[4] = {0};
   void* fake_freelist[7][4];
 
   fprintf(stderr, "\nWelcome to the House of Lore\n");


### PR DESCRIPTION
stack_buffer_2 gets out of range here:

```
stack_buffer_2[3] = (intptr_t *)fake_freelist[0];
```