### PR TITLE
Docker setup overhaul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,22 @@
-from ubuntu:20.04
+# Ubuntu 20.04 is used due to Issue #169
+ARG image=mcr.microsoft.com/devcontainers/base:focal 
+FROM $image
 
+# Build dependencies
 run apt-get update && apt-get install -y binutils git make vim gcc patchelf python-is-python3 python3-pip
-run pip3 install requests
+
+# Build how2heap
 run git clone --depth 1 https://github.com/shellphish/how2heap /root/how2heap
+run cd /root/how2heap && make clean all
+
+# pwndbg
+ENV LC_CTYPE=C.UTF-8 
+run git clone --depth 1 https://github.com/pwndbg/pwndbg /root/pwndbg 
 run git config --global --add safe.directory "*"
+run cd /root/pwndbg && ./setup.sh 
+
+# pwntools
+run pip3 install requests pwntools
+
 
 workdir /root/how2heap
-run bash

--- a/README.md
+++ b/README.md
@@ -68,20 +68,19 @@ Notice that it does not work if you compile the target binary (`malloc_playgroun
 
 ## Complete Setup
 
-This uses Docker-based approach to prepare the needed environment
+This uses Docker-based approach to prepare the needed environment with pwndbg
 
 ```shell
 git clone https://github.com/shellphish/how2heap
 cd how2heap
 
-# the next command will prepare the target binary so it runs with
-# the expected libc version
-./glibc_run.sh 2.30 ./malloc_playground -d -p
+docker build -t how2heap-pwndbg .
+docker run --rm -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined how2heap-pwndbg bash
 
-# now you can play with the binary with glibc-2.30
-# and even debug it with the correct symbols
-readelf -d -W malloc_playground | grep RUNPATH # or use checksec
-readelf -l -W malloc_playground | grep interpreter
+# Inside the docker container
+./glibc_run.sh 2.30 ./malloc_playground
+
+# Debugging with pwndbg
 gdb -q -ex "start" ./malloc_playground
 ```
 


### PR DESCRIPTION
This pull request creates a simple working Docker setup which sets up an environment containing pwndbg and pwntools, since the current one has an issue: #178


This pull request contains changes to Dockerfile and README.md to make the setup as simple as possible.
I also tried to make it as close as possible to the setup before.

