### PR TITLE
fixed sysmalloc_int_free.c MALLOC_ALIGN

### DIFF
--- a/glibc_2.23/sysmalloc_int_free.c
+++ b/glibc_2.23/sysmalloc_int_free.c
@@ -9,7 +9,6 @@
 #define SIZE_SZ sizeof(size_t)
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
-// same for x86_64 and x86
 #define MALLOC_ALIGN (SIZE_SZ*2)
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
@@ -28,10 +27,6 @@
 /**
  * Tested on:
  *  + GLIBC 2.23 (x86_64, x86 & aarch64)
- *  + GLIBC 2.39 (x86_64, x86 & aarch64)
- *  + GLIBC 2.34 (x86_64, x86 & aarch64)
- *  + GLIBC 2.31 (x86_64, x86 & aarch64)
- *  + GLIBC 2.27 (x86_64, x86 & aarch64)
  *
  * sysmalloc allows us to free() the top chunk of heap to create nearly arbitrary bins,
  * which can be used to corrupt heap without needing to call free() directly.

--- a/glibc_2.24/sysmalloc_int_free.c
+++ b/glibc_2.24/sysmalloc_int_free.c
@@ -9,7 +9,6 @@
 #define SIZE_SZ sizeof(size_t)
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
-// same for x86_64 and x86
 #define MALLOC_ALIGN (SIZE_SZ*2)
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
@@ -28,10 +27,6 @@
 /**
  * Tested on:
  *  + GLIBC 2.23 (x86_64, x86 & aarch64)
- *  + GLIBC 2.39 (x86_64, x86 & aarch64)
- *  + GLIBC 2.34 (x86_64, x86 & aarch64)
- *  + GLIBC 2.31 (x86_64, x86 & aarch64)
- *  + GLIBC 2.27 (x86_64, x86 & aarch64)
  *
  * sysmalloc allows us to free() the top chunk of heap to create nearly arbitrary bins,
  * which can be used to corrupt heap without needing to call free() directly.

--- a/glibc_2.27/sysmalloc_int_free.c
+++ b/glibc_2.27/sysmalloc_int_free.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
 // same for x86_64 and x86
-#define MALLOC_ALIGN (SIZE_SZ*2)
+#define MALLOC_ALIGN 0x10
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
 #define PAGESIZE sysconf(_SC_PAGESIZE)
@@ -27,7 +27,6 @@
 
 /**
  * Tested on:
- *  + GLIBC 2.23 (x86_64, x86 & aarch64)
  *  + GLIBC 2.39 (x86_64, x86 & aarch64)
  *  + GLIBC 2.34 (x86_64, x86 & aarch64)
  *  + GLIBC 2.31 (x86_64, x86 & aarch64)

--- a/glibc_2.31/sysmalloc_int_free.c
+++ b/glibc_2.31/sysmalloc_int_free.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
 // same for x86_64 and x86
-#define MALLOC_ALIGN (SIZE_SZ*2)
+#define MALLOC_ALIGN 0x10
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
 #define PAGESIZE sysconf(_SC_PAGESIZE)
@@ -27,7 +27,6 @@
 
 /**
  * Tested on:
- *  + GLIBC 2.23 (x86_64, x86 & aarch64)
  *  + GLIBC 2.39 (x86_64, x86 & aarch64)
  *  + GLIBC 2.34 (x86_64, x86 & aarch64)
  *  + GLIBC 2.31 (x86_64, x86 & aarch64)

--- a/glibc_2.32/sysmalloc_int_free.c
+++ b/glibc_2.32/sysmalloc_int_free.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
 // same for x86_64 and x86
-#define MALLOC_ALIGN (SIZE_SZ*2)
+#define MALLOC_ALIGN 0x10
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
 #define PAGESIZE sysconf(_SC_PAGESIZE)
@@ -27,7 +27,6 @@
 
 /**
  * Tested on:
- *  + GLIBC 2.23 (x86_64, x86 & aarch64)
  *  + GLIBC 2.39 (x86_64, x86 & aarch64)
  *  + GLIBC 2.34 (x86_64, x86 & aarch64)
  *  + GLIBC 2.31 (x86_64, x86 & aarch64)

--- a/glibc_2.33/sysmalloc_int_free.c
+++ b/glibc_2.33/sysmalloc_int_free.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
 // same for x86_64 and x86
-#define MALLOC_ALIGN (SIZE_SZ*2)
+#define MALLOC_ALIGN 0x10
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
 #define PAGESIZE sysconf(_SC_PAGESIZE)
@@ -27,7 +27,6 @@
 
 /**
  * Tested on:
- *  + GLIBC 2.23 (x86_64, x86 & aarch64)
  *  + GLIBC 2.39 (x86_64, x86 & aarch64)
  *  + GLIBC 2.34 (x86_64, x86 & aarch64)
  *  + GLIBC 2.31 (x86_64, x86 & aarch64)

--- a/glibc_2.34/sysmalloc_int_free.c
+++ b/glibc_2.34/sysmalloc_int_free.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
 // same for x86_64 and x86
-#define MALLOC_ALIGN (SIZE_SZ*2)
+#define MALLOC_ALIGN 0x10
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
 #define PAGESIZE sysconf(_SC_PAGESIZE)
@@ -27,7 +27,6 @@
 
 /**
  * Tested on:
- *  + GLIBC 2.23 (x86_64, x86 & aarch64)
  *  + GLIBC 2.39 (x86_64, x86 & aarch64)
  *  + GLIBC 2.34 (x86_64, x86 & aarch64)
  *  + GLIBC 2.31 (x86_64, x86 & aarch64)

--- a/glibc_2.35/sysmalloc_int_free.c
+++ b/glibc_2.35/sysmalloc_int_free.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
 // same for x86_64 and x86
-#define MALLOC_ALIGN (SIZE_SZ*2)
+#define MALLOC_ALIGN 0x10
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
 #define PAGESIZE sysconf(_SC_PAGESIZE)
@@ -27,7 +27,6 @@
 
 /**
  * Tested on:
- *  + GLIBC 2.23 (x86_64, x86 & aarch64)
  *  + GLIBC 2.39 (x86_64, x86 & aarch64)
  *  + GLIBC 2.34 (x86_64, x86 & aarch64)
  *  + GLIBC 2.31 (x86_64, x86 & aarch64)

--- a/glibc_2.36/sysmalloc_int_free.c
+++ b/glibc_2.36/sysmalloc_int_free.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
 // same for x86_64 and x86
-#define MALLOC_ALIGN (SIZE_SZ*2)
+#define MALLOC_ALIGN 0x10
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
 #define PAGESIZE sysconf(_SC_PAGESIZE)
@@ -27,7 +27,6 @@
 
 /**
  * Tested on:
- *  + GLIBC 2.23 (x86_64, x86 & aarch64)
  *  + GLIBC 2.39 (x86_64, x86 & aarch64)
  *  + GLIBC 2.34 (x86_64, x86 & aarch64)
  *  + GLIBC 2.31 (x86_64, x86 & aarch64)

--- a/glibc_2.37/sysmalloc_int_free.c
+++ b/glibc_2.37/sysmalloc_int_free.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
 // same for x86_64 and x86
-#define MALLOC_ALIGN (SIZE_SZ*2)
+#define MALLOC_ALIGN 0x10
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
 #define PAGESIZE sysconf(_SC_PAGESIZE)
@@ -27,7 +27,6 @@
 
 /**
  * Tested on:
- *  + GLIBC 2.23 (x86_64, x86 & aarch64)
  *  + GLIBC 2.39 (x86_64, x86 & aarch64)
  *  + GLIBC 2.34 (x86_64, x86 & aarch64)
  *  + GLIBC 2.31 (x86_64, x86 & aarch64)

--- a/glibc_2.38/sysmalloc_int_free.c
+++ b/glibc_2.38/sysmalloc_int_free.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
 // same for x86_64 and x86
-#define MALLOC_ALIGN (SIZE_SZ*2)
+#define MALLOC_ALIGN 0x10
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
 #define PAGESIZE sysconf(_SC_PAGESIZE)
@@ -27,7 +27,6 @@
 
 /**
  * Tested on:
- *  + GLIBC 2.23 (x86_64, x86 & aarch64)
  *  + GLIBC 2.39 (x86_64, x86 & aarch64)
  *  + GLIBC 2.34 (x86_64, x86 & aarch64)
  *  + GLIBC 2.31 (x86_64, x86 & aarch64)

--- a/glibc_2.39/sysmalloc_int_free.c
+++ b/glibc_2.39/sysmalloc_int_free.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_HDR_SZ (SIZE_SZ*2)
 // same for x86_64 and x86
-#define MALLOC_ALIGN (SIZE_SZ*2)
+#define MALLOC_ALIGN 0x10
 #define MALLOC_MASK (-MALLOC_ALIGN)
 
 #define PAGESIZE sysconf(_SC_PAGESIZE)
@@ -27,7 +27,6 @@
 
 /**
  * Tested on:
- *  + GLIBC 2.23 (x86_64, x86 & aarch64)
  *  + GLIBC 2.39 (x86_64, x86 & aarch64)
  *  + GLIBC 2.34 (x86_64, x86 & aarch64)
  *  + GLIBC 2.31 (x86_64, x86 & aarch64)


### PR DESCRIPTION
sry to bump this put i saw you modified sysmalloc_int_free.c https://github.com/shellphish/how2heap/commit/ae4dbf558203d72296e443e326d885b0f7994e63 https://github.com/shellphish/how2heap/commit/4ed6f1954565ed12e23aa84931ed9c36d00a3d8b
```diff
<< #define MALLOC_ALIGN 0x10L
>> #define MALLOC_ALIGN (SIZE_SZ*2)
```

i believe this happened because you merged the 2.23 example with the others,
but this breaks the showcase for x86 (32 bit), so maybe revert theses changes if possible?
in some earlier heap version glibc changed their heap alignment on x86 (32bit) to always be 0x10 (and not SIZE_SZ*2)
https://elixir.bootlin.com/glibc/glibc-2.39/source/sysdeps/i386/malloc-alignment.h#L22
this wasn't true for 2.23, that's why this version was slightly different
https://elixir.bootlin.com/glibc/glibc-2.23/source/malloc/malloc.c#L353