### PR TITLE
Bugfix, Makefile now works on oldlist versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ $(addprefix download_glibc_, $(VERSIONS)): libc_ready
 
 	version=$(patsubst download_glibc_%,%,$@); \
 	libc=$$(cat glibc-all-in-one/list | grep "$$version" | grep "$(ARCH)" | head -n 1); \
-	old_libc=$$(cat glibc-all-in-one/old_list | grep "$(version)" | grep "$(ARCH)" | head -n 1); \
+	old_libc=$$(cat glibc-all-in-one/old_list | grep "$$version" | grep "$(ARCH)" | head -n 1); \
 	if [ -z $$libc ]; then libc=$$old_libc; script="download_old"; else libc=$$libc; script="download"; fi; \
 	cd glibc-all-in-one; \
 	rm -rf libs/$$libc; \


### PR DESCRIPTION
The new Makefile Feature  #180 did not work for some glibc versions as it always downloaded `2.21-0ubuntu4.3_amd64` instead of the actual target version.

This affected every version inside of the "glibc-all-in-one/old_list", i.e. version 2.24, 2.26,2.28.

Bugtrace
```bash
$ H2H_USE_SYSTEM_LIBC=N make v2.24
git submodule update --init --recursive
cd glibc-all-in-one && ./update_list
[+] Common list has been save to "list"
[+] Old-release list has been save to "old_list"
download_glibc_2.24
version=2.24; \
libc=$(cat glibc-all-in-one/list | grep "$version" | grep "amd64" | head -n 1); \
old_libc=$(cat glibc-all-in-one/old_list | grep "" | grep "amd64" | head -n 1); \
if [ -z $libc ]; then libc=$old_libc; script="download_old"; else libc=$libc; script="download"; fi; \
cd glibc-all-in-one; \
rm -rf libs/$libc; \
./$script $libc
Getting 2.21-0ubuntu4.3_amd64
  -> Location: http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/libc6_2.21-0ubuntu4.3_amd64.deb
```

This pull request remedies the issue