### PR TITLE
fix incorrect address being printed in fastbin_dup_into_stack

### DIFF
--- a/glibc_2.33/fastbin_dup_into_stack.c
+++ b/glibc_2.33/fastbin_dup_into_stack.c
@@ -20,9 +20,9 @@ int main()
 	}
 
 
-	unsigned long stack_var[2] __attribute__ ((aligned (0x10)));
+	unsigned long stack_var[4] __attribute__ ((aligned (0x10)));
 
-	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var);
+	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var + 2);
 
 	fprintf(stderr, "Allocating 3 buffers.\n");
 	int *a = calloc(1,8);

--- a/glibc_2.34/fastbin_dup_into_stack.c
+++ b/glibc_2.34/fastbin_dup_into_stack.c
@@ -20,9 +20,9 @@ int main()
 	}
 
 
-	unsigned long stack_var[2] __attribute__ ((aligned (0x10)));
+	unsigned long stack_var[4] __attribute__ ((aligned (0x10)));
 
-	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var);
+	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var + 2);
 
 	fprintf(stderr, "Allocating 3 buffers.\n");
 	int *a = calloc(1,8);

--- a/glibc_2.36/fastbin_dup_into_stack.c
+++ b/glibc_2.36/fastbin_dup_into_stack.c
@@ -20,9 +20,9 @@ int main()
 	}
 
 
-	unsigned long stack_var[2] __attribute__ ((aligned (0x10)));
+	unsigned long stack_var[4] __attribute__ ((aligned (0x10)));
 
-	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var);
+	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var + 2);
 
 	fprintf(stderr, "Allocating 3 buffers.\n");
 	int *a = calloc(1,8);

--- a/glibc_2.37/fastbin_dup_into_stack.c
+++ b/glibc_2.37/fastbin_dup_into_stack.c
@@ -20,9 +20,9 @@ int main()
 	}
 
 
-	unsigned long stack_var[2] __attribute__ ((aligned (0x10)));
+	unsigned long stack_var[4] __attribute__ ((aligned (0x10)));
 
-	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var);
+	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var + 2);
 
 	fprintf(stderr, "Allocating 3 buffers.\n");
 	int *a = calloc(1,8);

--- a/glibc_2.38/fastbin_dup_into_stack.c
+++ b/glibc_2.38/fastbin_dup_into_stack.c
@@ -20,9 +20,9 @@ int main()
 	}
 
 
-	unsigned long stack_var[2] __attribute__ ((aligned (0x10)));
+	unsigned long stack_var[4] __attribute__ ((aligned (0x10)));
 
-	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var);
+	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var + 2);
 
 	fprintf(stderr, "Allocating 3 buffers.\n");
 	int *a = calloc(1,8);

--- a/glibc_2.39/fastbin_dup_into_stack.c
+++ b/glibc_2.39/fastbin_dup_into_stack.c
@@ -20,9 +20,9 @@ int main()
 	}
 
 
-	unsigned long stack_var[2] __attribute__ ((aligned (0x10)));
+	unsigned long stack_var[4] __attribute__ ((aligned (0x10)));
 
-	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var);
+	fprintf(stderr, "The address we want calloc() to return is %p.\n", stack_var + 2);
 
 	fprintf(stderr, "Allocating 3 buffers.\n");
 	int *a = calloc(1,8);


### PR DESCRIPTION
note that the assert at the end of the file is correct so this is really just an issue with the address that is printed

i've also increased the size of stack_var to match what is logically being used

note that a patch was made in 0a3ba0529f5d20778cae1377c56d2731b211fd2a fixing this issue

however the patch only fixed the issue for glibc_2.35 when it should have been applied to versions 2.33 -> 2.39