### PR TITLE
fix: incorrect p3 chunk range printed in overlapping_chunks

### DIFF
--- a/glibc_2.27/overlapping_chunks.c
+++ b/glibc_2.27/overlapping_chunks.c
@@ -58,7 +58,7 @@ int main(int argc , char* argv[])
 	p4 = malloc(evil_region_size);
 
 	printf("\np4 has been allocated at %p and ends at %p\n", (char *)p4, (char *)p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x580-8);
+	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x80-8);
 	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
 
 	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"

--- a/glibc_2.31/overlapping_chunks.c
+++ b/glibc_2.31/overlapping_chunks.c
@@ -56,7 +56,7 @@ int main(int argc , char* argv[])
 	p4 = malloc(evil_region_size);
 
 	printf("\np4 has been allocated at %p and ends at %p\n", (char *)p4, (char *)p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x580-8);
+	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x80-8);
 	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
 
 	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"

--- a/glibc_2.32/overlapping_chunks.c
+++ b/glibc_2.32/overlapping_chunks.c
@@ -56,7 +56,7 @@ int main(int argc , char* argv[])
 	p4 = malloc(evil_region_size);
 
 	printf("\np4 has been allocated at %p and ends at %p\n", (char *)p4, (char *)p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x580-8);
+	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x80-8);
 	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
 
 	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"

--- a/glibc_2.33/overlapping_chunks.c
+++ b/glibc_2.33/overlapping_chunks.c
@@ -56,7 +56,7 @@ int main(int argc , char* argv[])
 	p4 = malloc(evil_region_size);
 
 	printf("\np4 has been allocated at %p and ends at %p\n", (char *)p4, (char *)p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x580-8);
+	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x80-8);
 	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
 
 	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"

--- a/glibc_2.34/overlapping_chunks.c
+++ b/glibc_2.34/overlapping_chunks.c
@@ -56,7 +56,7 @@ int main(int argc , char* argv[])
 	p4 = malloc(evil_region_size);
 
 	printf("\np4 has been allocated at %p and ends at %p\n", (char *)p4, (char *)p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x580-8);
+	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x80-8);
 	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
 
 	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"

--- a/glibc_2.35/overlapping_chunks.c
+++ b/glibc_2.35/overlapping_chunks.c
@@ -56,7 +56,7 @@ int main(int argc , char* argv[])
 	p4 = malloc(evil_region_size);
 
 	printf("\np4 has been allocated at %p and ends at %p\n", (char *)p4, (char *)p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x580-8);
+	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x80-8);
 	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
 
 	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"

--- a/glibc_2.36/overlapping_chunks.c
+++ b/glibc_2.36/overlapping_chunks.c
@@ -56,7 +56,7 @@ int main(int argc , char* argv[])
 	p4 = malloc(evil_region_size);
 
 	printf("\np4 has been allocated at %p and ends at %p\n", (char *)p4, (char *)p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x580-8);
+	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x80-8);
 	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
 
 	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"

--- a/glibc_2.37/overlapping_chunks.c
+++ b/glibc_2.37/overlapping_chunks.c
@@ -56,7 +56,7 @@ int main(int argc , char* argv[])
 	p4 = malloc(evil_region_size);
 
 	printf("\np4 has been allocated at %p and ends at %p\n", (char *)p4, (char *)p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x580-8);
+	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x80-8);
 	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
 
 	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"

--- a/glibc_2.38/overlapping_chunks.c
+++ b/glibc_2.38/overlapping_chunks.c
@@ -56,7 +56,7 @@ int main(int argc , char* argv[])
 	p4 = malloc(evil_region_size);
 
 	printf("\np4 has been allocated at %p and ends at %p\n", (char *)p4, (char *)p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x580-8);
+	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x80-8);
 	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
 
 	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"

--- a/glibc_2.39/overlapping_chunks.c
+++ b/glibc_2.39/overlapping_chunks.c
@@ -56,7 +56,7 @@ int main(int argc , char* argv[])
 	p4 = malloc(evil_region_size);
 
 	printf("\np4 has been allocated at %p and ends at %p\n", (char *)p4, (char *)p4+evil_region_size);
-	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x580-8);
+	printf("p3 starts at %p and ends at %p\n", (char *)p3, (char *)p3+0x80-8);
 	printf("p4 should overlap with p3, in this case p4 includes all p3.\n");
 
 	printf("\nNow everything copied inside chunk p4 can overwrites data on\nchunk p3,"


### PR DESCRIPTION
Fixed incorrect printed size range of chunk p3.

Previously it printed `p3` as ending at `p3 + 0x580 - 8`, which corresponds to the size of p2/p4.
Corrected it to `p3 + 0x80 - 8` to match the actual malloc size.

This helps avoid confusion when analyzing the chunk overlap behavior.
