### PR TITLE
fix: remove misleading unnecessary bypass/comments on fake_chunk fields in House of Einherjar <2.26

### DIFF
--- a/glibc_2.23/house_of_einherjar.c
+++ b/glibc_2.23/house_of_einherjar.c
@@ -39,7 +39,7 @@ int main()
 	size_t fake_chunk[6];
 
 	fake_chunk[0] = 0x00; // The prev_size vs. size check is of no concern, until GLIBC 2.26 P->bk->size == P->prev_size check
-	fake_chunk[1] = 0x100; // size of the chunk just needs to be small enough to stay in the small bin
+	fake_chunk[1] = 0x00; // Arbitrary value; fake_chunk->size is ignored during backward consolidation.
 	fake_chunk[2] = (size_t) fake_chunk; // fwd
 	fake_chunk[3] = (size_t) fake_chunk; // bck
 	fake_chunk[4] = (size_t) fake_chunk; //fwd_nextsize

--- a/glibc_2.24/house_of_einherjar.c
+++ b/glibc_2.24/house_of_einherjar.c
@@ -39,7 +39,7 @@ int main()
 	size_t fake_chunk[6];
 
 	fake_chunk[0] = 0x00; // The prev_size vs. size check is of no concern, until GLIBC 2.26 P->bk->size == P->prev_size check
-	fake_chunk[1] = 0x100; // size of the chunk just needs to be small enough to stay in the small bin
+	fake_chunk[1] = 0x00; // Arbitrary value; fake_chunk->size is ignored during backward consolidation.
 	fake_chunk[2] = (size_t) fake_chunk; // fwd
 	fake_chunk[3] = (size_t) fake_chunk; // bck
 	fake_chunk[4] = (size_t) fake_chunk; //fwd_nextsize


### PR DESCRIPTION
There were two prerequisites mentioned for House of Einherjar 2.23 & 2.24, which I believe are incorrect assumptions:

1. The comment [HERE](https://github.com/shellphish/how2heap/blob/9cdc4e0802e1f6b7b81967ae690db3810802f647/glibc_2.23/house_of_einherjar.c#L41)  explicitly states that `fake_chunk->prev_size` and `fake_chunk->size` should be equal, which is not necessary, until GLIBC 2.26. This could be misleading, since in many cases one might be incapable of setting these two fields, which is totally fine because they play no role during exploit's run. 

2. The comment [HERE](https://github.com/shellphish/how2heap/blob/9cdc4e0802e1f6b7b81967ae690db3810802f647/glibc_2.23/house_of_einherjar.c#L42) also explicitly states that size of fake chunk should be in smallbins range, which is misleading because `fake_chunk->size` plays no role during backward consolidation, and is overwritten by `b->size + b->prev_size`. 

I've covered these two fixes for both 2.23 & 2.24 in two commits (Each for one problem). 