### PR TITLE
fix: when free argement is 2, properly releasing memory

### DIFF
--- a/malloc_playground.c
+++ b/malloc_playground.c
@@ -76,9 +76,9 @@ int main(int argc, char ** argv) {
 				}
 				else if (num == 2){
 					int tmpArg = atoi((const char *) &arg1);
+					free((void *) ptrArray[tmpArg]);
 					ptrArray[tmpArg] = 0;
 					sizeTable[tmpArg] = 0;
-					free((void *) ptrArray[tmpArg]);
 					ptrNumber -= 1;
 					fprintf(stderr, "==> ok\n");
 				}


### PR DESCRIPTION
In malloc_playground, the free command appeared ineffective because ptrArray[tmpArg] was being set to zero before the actual free call. This prevented pwndbg from correctly reflecting the freed state in heap. The fix ensures the pointer is preserved when invoking free.